### PR TITLE
Rename taskdb → tusk across the codebase

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-# claude-taskdb
+# claude-tusk
 
 A portable task management system for [Claude Code](https://claude.ai/claude-code) projects. Gives Claude a local SQLite database, CLI, and skills to track, prioritize, and work through tasks autonomously.
 
 ## What You Get
 
-- **`taskdb` CLI** — single entry point for all task database operations
+- **`tusk` CLI** — single entry point for all task database operations
 - **Skills** — Claude Code skills for task workflows (`/next-task`, `/groom-backlog`, `/check-dupes`, `/manage-dependencies`, `/tasks`)
 - **Scripts** — Python utilities for duplicate detection and dependency management
 - **Config-driven schema** — define your project's domains, task types, and agents in JSON; validation triggers are generated automatically
@@ -13,23 +13,23 @@ A portable task management system for [Claude Code](https://claude.ai/claude-cod
 
 ```bash
 # From your project root (must be a git repo)
-/path/to/claude-taskdb/install.sh
+/path/to/claude-tusk/install.sh
 ```
 
 This will:
-1. Install `.claude/bin/taskdb` and skills
-2. Create `taskdb/config.json` with defaults
-3. Initialize the database at `taskdb/tasks.db`
+1. Install `.claude/bin/tusk` and skills
+2. Create `tusk/config.json` with defaults
+3. Initialize the database at `tusk/tasks.db`
 
-Then edit `taskdb/config.json` to set your project's domains and agents, and re-init:
+Then edit `tusk/config.json` to set your project's domains and agents, and re-init:
 
 ```bash
-.claude/bin/taskdb init --force
+.claude/bin/tusk init --force
 ```
 
 ## Configuration
 
-Edit `taskdb/config.json` after install:
+Edit `tusk/config.json` after install:
 
 ```json
 {
@@ -53,15 +53,15 @@ Edit `taskdb/config.json` after install:
 ## CLI Reference
 
 ```bash
-.claude/bin/taskdb "SELECT ..."           # Run SQL
-.claude/bin/taskdb -header -column "SQL"   # With formatting flags
-.claude/bin/taskdb path                    # Print resolved DB path
-.claude/bin/taskdb config                  # Print full config JSON
-.claude/bin/taskdb config domains          # List valid domains
-.claude/bin/taskdb config agents           # List configured agents
-.claude/bin/taskdb init                    # Bootstrap DB (safe — skips if exists)
-.claude/bin/taskdb init --force            # Recreate DB from scratch
-.claude/bin/taskdb shell                   # Interactive sqlite3 shell
+.claude/bin/tusk "SELECT ..."           # Run SQL
+.claude/bin/tusk -header -column "SQL"   # With formatting flags
+.claude/bin/tusk path                    # Print resolved DB path
+.claude/bin/tusk config                  # Print full config JSON
+.claude/bin/tusk config domains          # List valid domains
+.claude/bin/tusk config agents           # List configured agents
+.claude/bin/tusk init                    # Bootstrap DB (safe — skips if exists)
+.claude/bin/tusk init --force            # Recreate DB from scratch
+.claude/bin/tusk shell                   # Interactive sqlite3 shell
 ```
 
 ## Skills
@@ -84,15 +84,15 @@ Add this to your project's `CLAUDE.md`:
 ```markdown
 ## Task Queue
 
-The project task database is managed via `.claude/bin/taskdb`. Use it for all task operations:
+The project task database is managed via `.claude/bin/tusk`. Use it for all task operations:
 
-    .claude/bin/taskdb "SELECT ..."          # Run SQL
-    .claude/bin/taskdb -header -column "SQL"  # With formatting flags
-    .claude/bin/taskdb path                   # Print resolved DB path
-    .claude/bin/taskdb config                 # Print project config
-    .claude/bin/taskdb init                   # Bootstrap DB
+    .claude/bin/tusk "SELECT ..."          # Run SQL
+    .claude/bin/tusk -header -column "SQL"  # With formatting flags
+    .claude/bin/tusk path                   # Print resolved DB path
+    .claude/bin/tusk config                 # Print project config
+    .claude/bin/tusk init                   # Bootstrap DB
 
-Never hardcode the DB path — always go through `taskdb`.
+Never hardcode the DB path — always go through `tusk`.
 ```
 
 ## Schema
@@ -125,13 +125,13 @@ Optional metrics tracking for time, cost, and token usage per task.
 
 ## How It Works
 
-The `taskdb` CLI is the single source of truth for the database path. Everything references it:
+The `tusk` CLI is the single source of truth for the database path. Everything references it:
 
-- **Skills** call `.claude/bin/taskdb "SQL"` (never raw `sqlite3`)
-- **Python scripts** resolve the path via `subprocess.check_output([".claude/bin/taskdb", "path"])`
-- **Config** lives at `taskdb/config.json`; triggers are generated from it at init time
+- **Skills** call `.claude/bin/tusk "SQL"` (never raw `sqlite3`)
+- **Python scripts** resolve the path via `subprocess.check_output([".claude/bin/tusk", "path"])`
+- **Config** lives at `tusk/config.json`; triggers are generated from it at init time
 
-If the DB path ever changes, update one line in `bin/taskdb`.
+If the DB path ever changes, update one line in `bin/tusk`.
 
 ## File Structure
 
@@ -141,8 +141,8 @@ After installation, your project will have:
 your-project/
 ├── .claude/
 │   ├── bin/
-│   │   ├── taskdb                  # CLI (single source of truth)
-│   │   └── config.default.json     # Fallback config
+│   │   ├── tusk                       # CLI (single source of truth)
+│   │   └── config.default.json        # Fallback config
 │   └── skills/
 │       ├── next-task/SKILL.md
 │       ├── groom-backlog/SKILL.md
@@ -152,7 +152,7 @@ your-project/
 ├── scripts/
 │   ├── check_duplicates.py
 │   └── manage_dependencies.py
-└── taskdb/
-    ├── config.json                 # Your project's config
-    └── tasks.db                    # The database
+└── tusk/
+    ├── config.json                    # Your project's config
+    └── tasks.db                       # The database
 ```

--- a/bin/tusk
+++ b/bin/tusk
@@ -1,18 +1,18 @@
 #!/usr/bin/env bash
 #
-# taskdb — single entry point for a project's task database.
+# tusk — single entry point for a project's task database.
 #
 # Usage:
-#   taskdb init [--force]        Create the DB with schema + triggers from config
-#   taskdb path                  Print the resolved DB path
-#   taskdb "SELECT ..."          Run a SQL statement
-#   taskdb -header -column "SQL" Pass sqlite3 flags + SQL
-#   taskdb shell                 Open an interactive sqlite3 shell
-#   taskdb config                Print full config JSON
-#   taskdb config <key>          Print config values (domains, task_types, agents, etc.)
+#   tusk init [--force]        Create the DB with schema + triggers from config
+#   tusk path                  Print the resolved DB path
+#   tusk "SELECT ..."          Run a SQL statement
+#   tusk -header -column "SQL" Pass sqlite3 flags + SQL
+#   tusk shell                 Open an interactive sqlite3 shell
+#   tusk config                Print full config JSON
+#   tusk config <key>          Print config values (domains, task_types, agents, etc.)
 #
 # Configuration:
-#   Project config:  <repo_root>/taskdb/config.json
+#   Project config:  <repo_root>/tusk/config.json
 #   Fallback:        <install_dir>/config.default.json
 #
 # The DB path is defined here. Everything else reads it from this script.
@@ -35,7 +35,7 @@ find_repo_root() {
 }
 
 REPO_ROOT="$(find_repo_root)"
-DB_DIR="$REPO_ROOT/taskdb"
+DB_DIR="$REPO_ROOT/tusk"
 DB_PATH="$DB_DIR/tasks.db"
 PROJECT_CONFIG="$DB_DIR/config.json"
 # Default config: check sibling (installed) then parent dir (source repo)
@@ -148,7 +148,7 @@ cmd_init() {
 
   if [[ -f "$DB_PATH" ]]; then
     echo "Database already exists at $DB_PATH"
-    echo "Use 'taskdb init --force' to recreate (existing data will be lost)."
+    echo "Use 'tusk init --force' to recreate (existing data will be lost)."
     [[ "${1:-}" == "--force" ]] || exit 0
     echo "Recreating database..."
     rm "$DB_PATH"
@@ -261,6 +261,6 @@ case "${1:-}" in
   path)   cmd_path ;;
   config) shift; cmd_config "$@" ;;
   shell)  cmd_shell ;;
-  "")     echo "Usage: taskdb {init|path|config|shell|\"SQL ...\"}" >&2; exit 1 ;;
+  "")     echo "Usage: tusk {init|path|config|shell|\"SQL ...\"}" >&2; exit 1 ;;
   *)      cmd_query "$@" ;;
 esac

--- a/install.sh
+++ b/install.sh
@@ -1,17 +1,17 @@
 #!/usr/bin/env bash
 #
-# Install claude-taskdb into a Claude Code project.
+# Install claude-tusk into a Claude Code project.
 #
 # Usage:
 #   cd /path/to/your/project
-#   /path/to/claude-taskdb/install.sh
+#   /path/to/claude-tusk/install.sh
 #
 # What it does:
-#   1. Copies bin/taskdb         → .claude/bin/taskdb
+#   1. Copies bin/tusk           → .claude/bin/tusk
 #   2. Copies skills/*           → .claude/skills/*
 #   3. Copies scripts/*          → scripts/*  (creates if needed)
 #   4. Copies config.default.json alongside bin for fallback
-#   5. Runs taskdb init (creates DB + config if missing)
+#   5. Runs tusk init (creates DB + config if missing)
 #   6. Prints CLAUDE.md snippet to paste into your project
 
 set -euo pipefail
@@ -25,13 +25,13 @@ if ! git rev-parse --show-toplevel &>/dev/null; then
 fi
 
 REPO_ROOT="$(git rev-parse --show-toplevel)"
-echo "Installing claude-taskdb into $REPO_ROOT"
+echo "Installing claude-tusk into $REPO_ROOT"
 
 # ── 1. Copy bin ──────────────────────────────────────────────────────
 mkdir -p "$REPO_ROOT/.claude/bin"
-cp "$SCRIPT_DIR/bin/taskdb" "$REPO_ROOT/.claude/bin/taskdb"
-chmod +x "$REPO_ROOT/.claude/bin/taskdb"
-echo "  Installed .claude/bin/taskdb"
+cp "$SCRIPT_DIR/bin/tusk" "$REPO_ROOT/.claude/bin/tusk"
+chmod +x "$REPO_ROOT/.claude/bin/tusk"
+echo "  Installed .claude/bin/tusk"
 
 # ── 2. Copy config default (fallback for bin) ────────────────────────
 cp "$SCRIPT_DIR/config.default.json" "$REPO_ROOT/.claude/bin/config.default.json"
@@ -60,7 +60,7 @@ for script in "$SCRIPT_DIR"/scripts/*.py; do
 done
 
 # ── 5. Init database ─────────────────────────────────────────────────
-"$REPO_ROOT/.claude/bin/taskdb" init
+"$REPO_ROOT/.claude/bin/tusk" init
 
 # ── 6. Print CLAUDE.md snippet ───────────────────────────────────────
 echo ""
@@ -70,28 +70,28 @@ echo "════════════════════════�
 echo ""
 echo "Next steps:"
 echo ""
-echo "  1. Edit taskdb/config.json to set your project's domains and agents"
+echo "  1. Edit tusk/config.json to set your project's domains and agents"
 echo ""
 echo "  2. Re-init to apply config changes:"
-echo "     .claude/bin/taskdb init --force"
+echo "     .claude/bin/tusk init --force"
 echo ""
 echo "  3. Add this to your CLAUDE.md:"
 echo ""
 cat <<'SNIPPET'
 ## Task Queue
 
-The project task database is managed via `.claude/bin/taskdb`. Use it for all task operations:
+The project task database is managed via `.claude/bin/tusk`. Use it for all task operations:
 
 ```bash
-.claude/bin/taskdb "SELECT ..."          # Run SQL
-.claude/bin/taskdb -header -column "SQL"  # With formatting flags
-.claude/bin/taskdb path                   # Print resolved DB path
-.claude/bin/taskdb config                 # Print project config
-.claude/bin/taskdb config domains         # List valid domains
-.claude/bin/taskdb init                   # Bootstrap DB (new projects)
-.claude/bin/taskdb shell                  # Interactive sqlite3 shell
+.claude/bin/tusk "SELECT ..."          # Run SQL
+.claude/bin/tusk -header -column "SQL"  # With formatting flags
+.claude/bin/tusk path                   # Print resolved DB path
+.claude/bin/tusk config                 # Print project config
+.claude/bin/tusk config domains         # List valid domains
+.claude/bin/tusk init                   # Bootstrap DB (new projects)
+.claude/bin/tusk shell                  # Interactive sqlite3 shell
 ```
 
-Never hardcode the DB path — always go through `taskdb`.
+Never hardcode the DB path — always go through `tusk`.
 SNIPPET
 echo ""

--- a/scripts/check_duplicates.py
+++ b/scripts/check_duplicates.py
@@ -10,7 +10,7 @@ import sys
 from difflib import SequenceMatcher
 
 DB_PATH = subprocess.check_output(
-    [".claude/bin/taskdb", "path"], text=True
+    [".claude/bin/tusk", "path"], text=True
 ).strip()
 
 DEFAULT_THRESHOLD = 0.82

--- a/scripts/manage_dependencies.py
+++ b/scripts/manage_dependencies.py
@@ -7,7 +7,7 @@ import subprocess
 import sys
 
 DB_PATH = subprocess.check_output(
-    [".claude/bin/taskdb", "path"], text=True
+    [".claude/bin/tusk", "path"], text=True
 ).strip()
 
 DEPENDENCIES_SCHEMA = """

--- a/skills/check-dupes/SKILL.md
+++ b/skills/check-dupes/SKILL.md
@@ -6,7 +6,7 @@ allowed-tools: Bash
 
 # Check Duplicates Skill
 
-Canonical deduplication gate for `taskdb`. Run this **before** inserting any task to avoid creating redundant work.
+Canonical deduplication gate for `tusk`. Run this **before** inserting any task to avoid creating redundant work.
 
 ## Usage
 

--- a/skills/groom-backlog/SKILL.md
+++ b/skills/groom-backlog/SKILL.md
@@ -13,9 +13,9 @@ Grooms the local task database by identifying completed, redundant, incorrectly 
 Before grooming, discover valid values for this project:
 
 ```bash
-.claude/bin/taskdb config domains
-.claude/bin/taskdb config agents
-.claude/bin/taskdb config task_types
+.claude/bin/tusk config domains
+.claude/bin/tusk config agents
+.claude/bin/tusk config task_types
 ```
 
 Use these values (not hardcoded ones) throughout the grooming process.
@@ -26,7 +26,7 @@ Before analyzing the backlog, close any deferred tasks that have passed their 60
 
 ```bash
 # Check how many deferred tasks have expired
-.claude/bin/taskdb -header -column "
+.claude/bin/tusk -header -column "
 SELECT COUNT(*) as expired_count
 FROM tasks
 WHERE summary LIKE '%[Deferred]%'
@@ -36,7 +36,7 @@ WHERE summary LIKE '%[Deferred]%'
 "
 
 # Auto-close expired deferred tasks
-.claude/bin/taskdb "
+.claude/bin/tusk "
 UPDATE tasks
 SET status = 'Done',
     closed_reason = 'expired',
@@ -54,9 +54,9 @@ Report how many were auto-closed before proceeding.
 ## Step 1: Fetch All Backlog Tasks
 
 ```bash
-.claude/bin/taskdb -header -column "SELECT id, summary, status, priority, domain, assignee FROM tasks WHERE status != 'Done' ORDER BY priority DESC, id"
+.claude/bin/tusk -header -column "SELECT id, summary, status, priority, domain, assignee FROM tasks WHERE status != 'Done' ORDER BY priority DESC, id"
 
-.claude/bin/taskdb -header -column "SELECT * FROM tasks WHERE status != 'Done'"
+.claude/bin/tusk -header -column "SELECT * FROM tasks WHERE status != 'Done'"
 
 python3 scripts/manage_dependencies.py blocked
 python3 scripts/manage_dependencies.py all
@@ -82,7 +82,7 @@ Tasks where the work has already been completed in the codebase:
 2. **Evidence required**: Provide specific file paths and code as proof
 3. **Mark as Done**:
    ```bash
-   .claude/bin/taskdb "UPDATE tasks SET status = 'Done', closed_reason = 'completed', updated_at = datetime('now') WHERE id = <id>"
+   .claude/bin/tusk "UPDATE tasks SET status = 'Done', closed_reason = 'completed', updated_at = datetime('now') WHERE id = <id>"
    ```
 
 ### Category B: Candidates for Deletion
@@ -104,10 +104,10 @@ python3 scripts/manage_dependencies.py dependents <id>
 Tasks without an agent assignee:
 
 ```bash
-.claude/bin/taskdb -header -column "SELECT id, summary, domain FROM tasks WHERE status != 'Done' AND assignee IS NULL"
+.claude/bin/tusk -header -column "SELECT id, summary, domain FROM tasks WHERE status != 'Done' AND assignee IS NULL"
 ```
 
-Assign based on project agents (from `taskdb config agents`).
+Assign based on project agents (from `tusk config agents`).
 
 ### Category E: Healthy Tasks
 Correctly prioritized, assigned, and relevant. No action needed.
@@ -115,7 +115,7 @@ Correctly prioritized, assigned, and relevant. No action needed.
 ## Step 3: Review Context
 
 ```bash
-.claude/bin/taskdb -header -column "SELECT * FROM tasks WHERE id = <id>"
+.claude/bin/tusk -header -column "SELECT * FROM tasks WHERE id = <id>"
 ```
 
 Also review recent commits and project documentation to understand current priorities.
@@ -154,31 +154,31 @@ Only after user approval:
 
 ### For Done Transitions:
 ```bash
-.claude/bin/taskdb "UPDATE tasks SET status = 'Done', closed_reason = 'completed', updated_at = datetime('now') WHERE id = <id>"
+.claude/bin/tusk "UPDATE tasks SET status = 'Done', closed_reason = 'completed', updated_at = datetime('now') WHERE id = <id>"
 ```
 
 ### For Deletions:
 ```bash
 # Duplicates:
-.claude/bin/taskdb "UPDATE tasks SET status = 'Done', closed_reason = 'duplicate', updated_at = datetime('now') WHERE id = <id>"
+.claude/bin/tusk "UPDATE tasks SET status = 'Done', closed_reason = 'duplicate', updated_at = datetime('now') WHERE id = <id>"
 
 # Obsolete/won't-do:
-.claude/bin/taskdb "UPDATE tasks SET status = 'Done', closed_reason = 'wont_do', updated_at = datetime('now') WHERE id = <id>"
+.claude/bin/tusk "UPDATE tasks SET status = 'Done', closed_reason = 'wont_do', updated_at = datetime('now') WHERE id = <id>"
 ```
 
 ### For Priority Changes:
 ```bash
-.claude/bin/taskdb "UPDATE tasks SET priority = '<New Priority>' WHERE id = <id>"
+.claude/bin/tusk "UPDATE tasks SET priority = '<New Priority>' WHERE id = <id>"
 ```
 
 ### For Agent Assignments:
 ```bash
-.claude/bin/taskdb "UPDATE tasks SET assignee = '<agent-name>' WHERE id = <id>"
+.claude/bin/tusk "UPDATE tasks SET assignee = '<agent-name>' WHERE id = <id>"
 ```
 
 ### After Each Change:
 ```bash
-.claude/bin/taskdb -header -column "SELECT id, summary, status, priority FROM tasks WHERE id = <id>"
+.claude/bin/tusk -header -column "SELECT id, summary, status, priority FROM tasks WHERE id = <id>"
 ```
 
 ## Step 7: Compute Priority Scores
@@ -197,7 +197,7 @@ Where:
 - **unblocks_bonus**: +5 per dependent task, capped at +15
 
 ```bash
-.claude/bin/taskdb "
+.claude/bin/tusk "
 UPDATE tasks SET priority_score = (
   CASE priority
     WHEN 'Highest' THEN 100
@@ -218,7 +218,7 @@ WHERE status != 'Done';
 "
 
 # Verify
-.claude/bin/taskdb -header -column "
+.claude/bin/tusk -header -column "
 SELECT id, summary, priority, priority_score
 FROM tasks
 WHERE status = 'To Do'
@@ -242,7 +242,7 @@ LIMIT 15;
 
 Show final backlog state:
 ```bash
-.claude/bin/taskdb -header -column "SELECT id, summary, status, priority, domain, assignee FROM tasks WHERE status != 'Done' ORDER BY priority DESC, id"
+.claude/bin/tusk -header -column "SELECT id, summary, status, priority, domain, assignee FROM tasks WHERE status != 'Done' ORDER BY priority DESC, id"
 ```
 
 ## Important Guidelines

--- a/skills/manage-dependencies/SKILL.md
+++ b/skills/manage-dependencies/SKILL.md
@@ -6,7 +6,7 @@ allowed-tools: Bash
 
 # Manage Dependencies Skill
 
-Manages task dependencies in the project task database (via `taskdb` CLI). Dependencies define which tasks must be completed before another task can be started.
+Manages task dependencies in the project task database (via `tusk` CLI). Dependencies define which tasks must be completed before another task can be started.
 
 ## Commands
 

--- a/skills/next-task/SKILL.md
+++ b/skills/next-task/SKILL.md
@@ -6,15 +6,15 @@ allowed-tools: Bash, Task, Read, Edit, Write, Grep, Glob
 
 # Next Task Skill
 
-The primary interface for working with tasks from the project task database (via `taskdb` CLI). Use this to get the next task, start working on it, and manage the full development workflow.
+The primary interface for working with tasks from the project task database (via `tusk` CLI). Use this to get the next task, start working on it, and manage the full development workflow.
 
 ## Setup: Discover Project Config
 
 Before any operation that needs domain or agent values, run:
 
 ```bash
-.claude/bin/taskdb config domains
-.claude/bin/taskdb config agents
+.claude/bin/tusk config domains
+.claude/bin/tusk config agents
 ```
 
 Use the returned values (not hardcoded ones) when validating or inserting tasks.
@@ -26,7 +26,7 @@ Use the returned values (not hardcoded ones) when validating or inserting tasks.
 Finds the highest-priority task that is ready to work on (no incomplete dependencies) and **automatically begins working on it**.
 
 ```bash
-.claude/bin/taskdb -header -column "
+.claude/bin/tusk -header -column "
 SELECT t.id, t.summary, t.priority, t.priority_score, t.domain, t.assignee, t.description
 FROM tasks t
 WHERE t.status = 'To Do'
@@ -52,12 +52,12 @@ When called with a task ID (e.g., `/next-task 6`), begin the full development wo
 
 1. **Fetch the task** from the database:
    ```bash
-   .claude/bin/taskdb -header -column "SELECT * FROM tasks WHERE id = <id>"
+   .claude/bin/tusk -header -column "SELECT * FROM tasks WHERE id = <id>"
    ```
 
 2. **Update the task status** to In Progress:
    ```bash
-   .claude/bin/taskdb "UPDATE tasks SET status = 'In Progress', updated_at = datetime('now') WHERE id = <id>"
+   .claude/bin/tusk "UPDATE tasks SET status = 'In Progress', updated_at = datetime('now') WHERE id = <id>"
    ```
 
 3. **Extract task details** including:
@@ -103,7 +103,7 @@ When called with a task ID (e.g., `/next-task 6`), begin the full development wo
 
 11. **Update the task with the PR URL**:
     ```bash
-    .claude/bin/taskdb "UPDATE tasks SET github_pr = '<pr_url>', updated_at = datetime('now') WHERE id = <id>"
+    .claude/bin/tusk "UPDATE tasks SET github_pr = '<pr_url>', updated_at = datetime('now') WHERE id = <id>"
     ```
 
 12. **Review loop — iterate until approved**:
@@ -152,7 +152,7 @@ When called with a task ID (e.g., `/next-task 6`), begin the full development wo
        ```
     2. Create a deferred task (with 60-day expiry):
        ```bash
-       .claude/bin/taskdb "INSERT INTO tasks (summary, description, status, priority, domain, created_at, updated_at, expires_at)
+       .claude/bin/tusk "INSERT INTO tasks (summary, description, status, priority, domain, created_at, updated_at, expires_at)
          VALUES ('[Deferred] <brief description>', 'Deferred from PR #<pr_number> review for TASK-<id>.
 
 Original comment: <comment text>
@@ -168,12 +168,12 @@ Reason deferred: <why this can wait>', 'To Do', 'Low', '<domain>', datetime('now
 
     Update task status:
     ```bash
-    .claude/bin/taskdb "UPDATE tasks SET status = 'Done', closed_reason = 'completed', updated_at = datetime('now') WHERE id = <id>"
+    .claude/bin/tusk "UPDATE tasks SET status = 'Done', closed_reason = 'completed', updated_at = datetime('now') WHERE id = <id>"
     ```
 
 14. **Check for newly unblocked tasks**:
     ```bash
-    .claude/bin/taskdb -header -column "
+    .claude/bin/tusk -header -column "
     SELECT t.id, t.summary, t.priority
     FROM tasks t
     JOIN task_dependencies d ON t.id = d.task_id
@@ -186,7 +186,7 @@ Reason deferred: <why this can wait>', 'To Do', 'Low', '<domain>', datetime('now
 When called with `done <id>`:
 
 ```bash
-.claude/bin/taskdb "UPDATE tasks SET status = 'Done', closed_reason = 'completed', updated_at = datetime('now') WHERE id = <id>"
+.claude/bin/tusk "UPDATE tasks SET status = 'Done', closed_reason = 'completed', updated_at = datetime('now') WHERE id = <id>"
 ```
 
 Then show newly unblocked tasks.
@@ -196,7 +196,7 @@ Then show newly unblocked tasks.
 When called with `view <id>`:
 
 ```bash
-.claude/bin/taskdb -header -column "SELECT * FROM tasks WHERE id = <id>"
+.claude/bin/tusk -header -column "SELECT * FROM tasks WHERE id = <id>"
 ```
 
 ### List Top N Ready Tasks
@@ -204,7 +204,7 @@ When called with `view <id>`:
 When called with `list <n>` or just a number:
 
 ```bash
-.claude/bin/taskdb -header -column "
+.claude/bin/tusk -header -column "
 SELECT t.id, t.summary, t.priority, t.domain, t.assignee
 FROM tasks t
 WHERE t.status = 'To Do'
@@ -231,7 +231,7 @@ When called with `assignee <value>`: Get next ready task for that assignee only.
 When called with `blocked`:
 
 ```bash
-.claude/bin/taskdb -header -column "
+.claude/bin/tusk -header -column "
 SELECT t.id, t.summary, t.priority,
   (SELECT GROUP_CONCAT(d.depends_on_id) FROM task_dependencies d WHERE d.task_id = t.id) as blocked_by
 FROM tasks t
@@ -250,7 +250,7 @@ ORDER BY t.id
 When called with `wip` or `in-progress`:
 
 ```bash
-.claude/bin/taskdb -header -column "SELECT id, summary, priority, domain, assignee, github_pr FROM tasks WHERE status = 'In Progress'"
+.claude/bin/tusk -header -column "SELECT id, summary, priority, domain, assignee, github_pr FROM tasks WHERE status = 'In Progress'"
 ```
 
 ### Preview Next Task (without starting)
@@ -258,7 +258,7 @@ When called with `wip` or `in-progress`:
 When called with `preview`: Show the next ready task but do NOT start working on it.
 
 ```bash
-.claude/bin/taskdb -header -column "
+.claude/bin/tusk -header -column "
 SELECT t.id, t.summary, t.priority, t.domain, t.assignee, t.description
 FROM tasks t
 WHERE t.status = 'To Do'
@@ -289,7 +289,7 @@ LIMIT 1;
 
 ## Canonical Values
 
-Run `.claude/bin/taskdb config` to see all valid values for this project. Using non-canonical values will be rejected by SQLite triggers.
+Run `.claude/bin/tusk config` to see all valid values for this project. Using non-canonical values will be rejected by SQLite triggers.
 
 ### Closed Reason (set when status = Done)
 `completed`, `expired`, `wont_do`, `duplicate`

--- a/skills/tasks/SKILL.md
+++ b/skills/tasks/SKILL.md
@@ -6,14 +6,14 @@ allowed-tools: Bash
 
 # Tasks Skill
 
-Opens the project task database (via `taskdb` CLI) in DB Browser for SQLite for visual browsing and querying.
+Opens the project task database (via `tusk` CLI) in DB Browser for SQLite for visual browsing and querying.
 
 ## Usage
 
 When this skill is invoked, run:
 
 ```bash
-open -a "DB Browser for SQLite" "$(.claude/bin/taskdb path)"
+open -a "DB Browser for SQLite" "$(.claude/bin/tusk path)"
 ```
 
 Then confirm to the user that the database has been opened in DB Browser for SQLite.
@@ -23,5 +23,5 @@ Then confirm to the user that the database has been opened in DB Browser for SQL
 Before opening, show a quick summary:
 
 ```bash
-.claude/bin/taskdb "SELECT status, COUNT(*) as count FROM tasks GROUP BY status ORDER BY count DESC"
+.claude/bin/tusk "SELECT status, COUNT(*) as count FROM tasks GROUP BY status ORDER BY count DESC"
 ```


### PR DESCRIPTION
## Summary
- Renames the CLI binary from `bin/taskdb` to `bin/tusk`
- Updates the data directory path from `taskdb/` to `tusk/` in all references
- Replaces all `taskdb` references across 11 files: install script, Python scripts, all 5 skill SKILL.md files, README.md, and CLAUDE.md

## Test plan
- [x] `bin/tusk init --force` creates `tusk/tasks.db` successfully
- [x] `bin/tusk path` and SQL queries work correctly
- [x] Grep for `taskdb` returns zero matches across the codebase

🤖 Generated with [Claude Code](https://claude.com/claude-code)