### PR TITLE
Replace .claude/bin/tusk with tusk

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,7 +33,7 @@ There is no build step, test suite, or linter in this repository.
 
 ### Single Source of Truth: `bin/tusk`
 
-The bash CLI resolves all paths dynamically. The database lives at `<repo_root>/tusk/tasks.db`. Everything references `bin/tusk` — skills call it for SQL, Python scripts call `subprocess.check_output([".claude/bin/tusk", "path"])` to resolve the DB path. Never hardcode the database path.
+The bash CLI resolves all paths dynamically. The database lives at `<repo_root>/tusk/tasks.db`. Everything references `bin/tusk` — skills call it for SQL, Python scripts call `subprocess.check_output(["tusk", "path"])` to resolve the DB path. Never hardcode the database path.
 
 ### Config-Driven Validation
 
@@ -60,7 +60,7 @@ Three tables: `tasks` (13 columns — summary, status, priority, domain, assigne
 
 ### Installation Model
 
-`install.sh` copies `bin/tusk` → `.claude/bin/tusk`, skills → `.claude/skills/`, scripts → `scripts/`, and runs `tusk init`. This repo is the source; target projects get the installed copy.
+`install.sh` copies `bin/tusk` → `tusk` (on PATH), skills → `.claude/skills/`, scripts → `scripts/`, and runs `tusk init`. This repo is the source; target projects get the installed copy.
 
 ## Key Conventions
 

--- a/README.md
+++ b/README.md
@@ -21,14 +21,14 @@ cd /path/to/your/project
 ```
 
 This will:
-1. Install `.claude/bin/tusk`, skills, scripts, and default config
+1. Install `tusk`, skills, scripts, and default config
 2. Create `tusk/config.json` with defaults
 3. Initialize the database at `tusk/tasks.db`
 
 Then edit `tusk/config.json` to set your project's domains and agents, and re-init:
 
 ```bash
-.claude/bin/tusk init --force
+tusk init --force
 ```
 
 ## Configuration
@@ -57,15 +57,15 @@ Edit `tusk/config.json` after install:
 ## CLI Reference
 
 ```bash
-.claude/bin/tusk "SELECT ..."           # Run SQL
-.claude/bin/tusk -header -column "SQL"   # With formatting flags
-.claude/bin/tusk path                    # Print resolved DB path
-.claude/bin/tusk config                  # Print full config JSON
-.claude/bin/tusk config domains          # List valid domains
-.claude/bin/tusk config agents           # List configured agents
-.claude/bin/tusk init                    # Bootstrap DB (safe — skips if exists)
-.claude/bin/tusk init --force            # Recreate DB from scratch
-.claude/bin/tusk shell                   # Interactive sqlite3 shell
+tusk "SELECT ..."           # Run SQL
+tusk -header -column "SQL"   # With formatting flags
+tusk path                    # Print resolved DB path
+tusk config                  # Print full config JSON
+tusk config domains          # List valid domains
+tusk config agents           # List configured agents
+tusk init                    # Bootstrap DB (safe — skips if exists)
+tusk init --force            # Recreate DB from scratch
+tusk shell                   # Interactive sqlite3 shell
 ```
 
 ## Skills
@@ -88,13 +88,13 @@ Add this to your project's `CLAUDE.md`:
 ```markdown
 ## Task Queue
 
-The project task database is managed via `.claude/bin/tusk`. Use it for all task operations:
+The project task database is managed via `tusk`. Use it for all task operations:
 
-    .claude/bin/tusk "SELECT ..."          # Run SQL
-    .claude/bin/tusk -header -column "SQL"  # With formatting flags
-    .claude/bin/tusk path                   # Print resolved DB path
-    .claude/bin/tusk config                 # Print project config
-    .claude/bin/tusk init                   # Bootstrap DB
+    tusk "SELECT ..."          # Run SQL
+    tusk -header -column "SQL"  # With formatting flags
+    tusk path                   # Print resolved DB path
+    tusk config                 # Print project config
+    tusk init                   # Bootstrap DB
 
 Never hardcode the DB path — always go through `tusk`.
 ```
@@ -131,8 +131,8 @@ Optional metrics tracking for time, cost, and token usage per task.
 
 The `tusk` CLI is the single source of truth for the database path. Everything references it:
 
-- **Skills** call `.claude/bin/tusk "SQL"` (never raw `sqlite3`)
-- **Python scripts** resolve the path via `subprocess.check_output([".claude/bin/tusk", "path"])`
+- **Skills** call `tusk "SQL"` (never raw `sqlite3`)
+- **Python scripts** resolve the path via `subprocess.check_output(["tusk", "path"])`
 - **Config** lives at `tusk/config.json`; triggers are generated from it at init time
 
 If the DB path ever changes, update one line in `bin/tusk`.

--- a/install.sh
+++ b/install.sh
@@ -7,7 +7,7 @@
 #   /path/to/tusker/install.sh
 #
 # What it does:
-#   1. Copies bin/tusk           → .claude/bin/tusk
+#   1. Copies bin/tusk           → tusk
 #   2. Copies skills/*           → .claude/skills/*
 #   3. Copies scripts/*          → scripts/*  (creates if needed)
 #   4. Copies config.default.json alongside bin for fallback
@@ -36,9 +36,9 @@ echo "Installing tusker into $REPO_ROOT"
 
 # ── 1. Copy bin ──────────────────────────────────────────────────────
 mkdir -p "$REPO_ROOT/.claude/bin"
-cp "$SCRIPT_DIR/bin/tusk" "$REPO_ROOT/.claude/bin/tusk"
-chmod +x "$REPO_ROOT/.claude/bin/tusk"
-echo "  Installed .claude/bin/tusk"
+cp "$SCRIPT_DIR/bin/tusk" "$REPO_ROOT/tusk"
+chmod +x "$REPO_ROOT/tusk"
+echo "  Installed tusk"
 
 # ── 2. Copy config default (fallback for bin) ────────────────────────
 cp "$SCRIPT_DIR/config.default.json" "$REPO_ROOT/.claude/bin/config.default.json"
@@ -63,7 +63,7 @@ for script in "$SCRIPT_DIR"/scripts/*.py; do
 done
 
 # ── 5. Init database ─────────────────────────────────────────────────
-"$REPO_ROOT/.claude/bin/tusk" init
+"$REPO_ROOT/tusk" init
 
 # ── 6. Print CLAUDE.md snippet ───────────────────────────────────────
 echo ""
@@ -76,23 +76,23 @@ echo ""
 echo "  1. Edit tusk/config.json to set your project's domains and agents"
 echo ""
 echo "  2. Re-init to apply config changes:"
-echo "     .claude/bin/tusk init --force"
+echo "     tusk init --force"
 echo ""
 echo "  3. Add this to your CLAUDE.md:"
 echo ""
 cat <<'SNIPPET'
 ## Task Queue
 
-The project task database is managed via `.claude/bin/tusk`. Use it for all task operations:
+The project task database is managed via `tusk`. Use it for all task operations:
 
 ```bash
-.claude/bin/tusk "SELECT ..."          # Run SQL
-.claude/bin/tusk -header -column "SQL"  # With formatting flags
-.claude/bin/tusk path                   # Print resolved DB path
-.claude/bin/tusk config                 # Print project config
-.claude/bin/tusk config domains         # List valid domains
-.claude/bin/tusk init                   # Bootstrap DB (new projects)
-.claude/bin/tusk shell                  # Interactive sqlite3 shell
+tusk "SELECT ..."          # Run SQL
+tusk -header -column "SQL"  # With formatting flags
+tusk path                   # Print resolved DB path
+tusk config                 # Print project config
+tusk config domains         # List valid domains
+tusk init                   # Bootstrap DB (new projects)
+tusk shell                  # Interactive sqlite3 shell
 ```
 
 Never hardcode the DB path — always go through `tusk`.

--- a/scripts/check_duplicates.py
+++ b/scripts/check_duplicates.py
@@ -10,7 +10,7 @@ import sys
 from difflib import SequenceMatcher
 
 DB_PATH = subprocess.check_output(
-    [".claude/bin/tusk", "path"], text=True
+    ["tusk", "path"], text=True
 ).strip()
 
 DEFAULT_THRESHOLD = 0.82

--- a/scripts/manage_dependencies.py
+++ b/scripts/manage_dependencies.py
@@ -7,7 +7,7 @@ import subprocess
 import sys
 
 DB_PATH = subprocess.check_output(
-    [".claude/bin/tusk", "path"], text=True
+    ["tusk", "path"], text=True
 ).strip()
 
 DEPENDENCIES_SCHEMA = """

--- a/skills/groom-backlog/SKILL.md
+++ b/skills/groom-backlog/SKILL.md
@@ -13,9 +13,9 @@ Grooms the local task database by identifying completed, redundant, incorrectly 
 Before grooming, discover valid values for this project:
 
 ```bash
-.claude/bin/tusk config domains
-.claude/bin/tusk config agents
-.claude/bin/tusk config task_types
+tusk config domains
+tusk config agents
+tusk config task_types
 ```
 
 Use these values (not hardcoded ones) throughout the grooming process.
@@ -26,7 +26,7 @@ Before analyzing the backlog, close any deferred tasks that have passed their 60
 
 ```bash
 # Check how many deferred tasks have expired
-.claude/bin/tusk -header -column "
+tusk -header -column "
 SELECT COUNT(*) as expired_count
 FROM tasks
 WHERE summary LIKE '%[Deferred]%'
@@ -36,7 +36,7 @@ WHERE summary LIKE '%[Deferred]%'
 "
 
 # Auto-close expired deferred tasks
-.claude/bin/tusk "
+tusk "
 UPDATE tasks
 SET status = 'Done',
     closed_reason = 'expired',
@@ -54,9 +54,9 @@ Report how many were auto-closed before proceeding.
 ## Step 1: Fetch All Backlog Tasks
 
 ```bash
-.claude/bin/tusk -header -column "SELECT id, summary, status, priority, domain, assignee FROM tasks WHERE status != 'Done' ORDER BY priority DESC, id"
+tusk -header -column "SELECT id, summary, status, priority, domain, assignee FROM tasks WHERE status != 'Done' ORDER BY priority DESC, id"
 
-.claude/bin/tusk -header -column "SELECT * FROM tasks WHERE status != 'Done'"
+tusk -header -column "SELECT * FROM tasks WHERE status != 'Done'"
 
 python3 scripts/manage_dependencies.py blocked
 python3 scripts/manage_dependencies.py all
@@ -82,7 +82,7 @@ Tasks where the work has already been completed in the codebase:
 2. **Evidence required**: Provide specific file paths and code as proof
 3. **Mark as Done**:
    ```bash
-   .claude/bin/tusk "UPDATE tasks SET status = 'Done', closed_reason = 'completed', updated_at = datetime('now') WHERE id = <id>"
+   tusk "UPDATE tasks SET status = 'Done', closed_reason = 'completed', updated_at = datetime('now') WHERE id = <id>"
    ```
 
 ### Category B: Candidates for Deletion
@@ -104,7 +104,7 @@ python3 scripts/manage_dependencies.py dependents <id>
 Tasks without an agent assignee:
 
 ```bash
-.claude/bin/tusk -header -column "SELECT id, summary, domain FROM tasks WHERE status != 'Done' AND assignee IS NULL"
+tusk -header -column "SELECT id, summary, domain FROM tasks WHERE status != 'Done' AND assignee IS NULL"
 ```
 
 Assign based on project agents (from `tusk config agents`).
@@ -115,7 +115,7 @@ Correctly prioritized, assigned, and relevant. No action needed.
 ## Step 3: Review Context
 
 ```bash
-.claude/bin/tusk -header -column "SELECT * FROM tasks WHERE id = <id>"
+tusk -header -column "SELECT * FROM tasks WHERE id = <id>"
 ```
 
 Also review recent commits and project documentation to understand current priorities.
@@ -154,31 +154,31 @@ Only after user approval:
 
 ### For Done Transitions:
 ```bash
-.claude/bin/tusk "UPDATE tasks SET status = 'Done', closed_reason = 'completed', updated_at = datetime('now') WHERE id = <id>"
+tusk "UPDATE tasks SET status = 'Done', closed_reason = 'completed', updated_at = datetime('now') WHERE id = <id>"
 ```
 
 ### For Deletions:
 ```bash
 # Duplicates:
-.claude/bin/tusk "UPDATE tasks SET status = 'Done', closed_reason = 'duplicate', updated_at = datetime('now') WHERE id = <id>"
+tusk "UPDATE tasks SET status = 'Done', closed_reason = 'duplicate', updated_at = datetime('now') WHERE id = <id>"
 
 # Obsolete/won't-do:
-.claude/bin/tusk "UPDATE tasks SET status = 'Done', closed_reason = 'wont_do', updated_at = datetime('now') WHERE id = <id>"
+tusk "UPDATE tasks SET status = 'Done', closed_reason = 'wont_do', updated_at = datetime('now') WHERE id = <id>"
 ```
 
 ### For Priority Changes:
 ```bash
-.claude/bin/tusk "UPDATE tasks SET priority = '<New Priority>' WHERE id = <id>"
+tusk "UPDATE tasks SET priority = '<New Priority>' WHERE id = <id>"
 ```
 
 ### For Agent Assignments:
 ```bash
-.claude/bin/tusk "UPDATE tasks SET assignee = '<agent-name>' WHERE id = <id>"
+tusk "UPDATE tasks SET assignee = '<agent-name>' WHERE id = <id>"
 ```
 
 ### After Each Change:
 ```bash
-.claude/bin/tusk -header -column "SELECT id, summary, status, priority FROM tasks WHERE id = <id>"
+tusk -header -column "SELECT id, summary, status, priority FROM tasks WHERE id = <id>"
 ```
 
 ## Step 7: Compute Priority Scores
@@ -197,7 +197,7 @@ Where:
 - **unblocks_bonus**: +5 per dependent task, capped at +15
 
 ```bash
-.claude/bin/tusk "
+tusk "
 UPDATE tasks SET priority_score = (
   CASE priority
     WHEN 'Highest' THEN 100
@@ -218,7 +218,7 @@ WHERE status != 'Done';
 "
 
 # Verify
-.claude/bin/tusk -header -column "
+tusk -header -column "
 SELECT id, summary, priority, priority_score
 FROM tasks
 WHERE status = 'To Do'
@@ -242,7 +242,7 @@ LIMIT 15;
 
 Show final backlog state:
 ```bash
-.claude/bin/tusk -header -column "SELECT id, summary, status, priority, domain, assignee FROM tasks WHERE status != 'Done' ORDER BY priority DESC, id"
+tusk -header -column "SELECT id, summary, status, priority, domain, assignee FROM tasks WHERE status != 'Done' ORDER BY priority DESC, id"
 ```
 
 ## Important Guidelines

--- a/skills/next-task/SKILL.md
+++ b/skills/next-task/SKILL.md
@@ -13,8 +13,8 @@ The primary interface for working with tasks from the project task database (via
 Before any operation that needs domain or agent values, run:
 
 ```bash
-.claude/bin/tusk config domains
-.claude/bin/tusk config agents
+tusk config domains
+tusk config agents
 ```
 
 Use the returned values (not hardcoded ones) when validating or inserting tasks.
@@ -26,7 +26,7 @@ Use the returned values (not hardcoded ones) when validating or inserting tasks.
 Finds the highest-priority task that is ready to work on (no incomplete dependencies) and **automatically begins working on it**.
 
 ```bash
-.claude/bin/tusk -header -column "
+tusk -header -column "
 SELECT t.id, t.summary, t.priority, t.priority_score, t.domain, t.assignee, t.description
 FROM tasks t
 WHERE t.status = 'To Do'
@@ -52,12 +52,12 @@ When called with a task ID (e.g., `/next-task 6`), begin the full development wo
 
 1. **Fetch the task** from the database:
    ```bash
-   .claude/bin/tusk -header -column "SELECT * FROM tasks WHERE id = <id>"
+   tusk -header -column "SELECT * FROM tasks WHERE id = <id>"
    ```
 
 2. **Update the task status** to In Progress:
    ```bash
-   .claude/bin/tusk "UPDATE tasks SET status = 'In Progress', updated_at = datetime('now') WHERE id = <id>"
+   tusk "UPDATE tasks SET status = 'In Progress', updated_at = datetime('now') WHERE id = <id>"
    ```
 
 3. **Extract task details** including:
@@ -103,7 +103,7 @@ When called with a task ID (e.g., `/next-task 6`), begin the full development wo
 
 11. **Update the task with the PR URL**:
     ```bash
-    .claude/bin/tusk "UPDATE tasks SET github_pr = '<pr_url>', updated_at = datetime('now') WHERE id = <id>"
+    tusk "UPDATE tasks SET github_pr = '<pr_url>', updated_at = datetime('now') WHERE id = <id>"
     ```
 
 12. **Review loop — iterate until approved**:
@@ -152,7 +152,7 @@ When called with a task ID (e.g., `/next-task 6`), begin the full development wo
        ```
     2. Create a deferred task (with 60-day expiry):
        ```bash
-       .claude/bin/tusk "INSERT INTO tasks (summary, description, status, priority, domain, created_at, updated_at, expires_at)
+       tusk "INSERT INTO tasks (summary, description, status, priority, domain, created_at, updated_at, expires_at)
          VALUES ('[Deferred] <brief description>', 'Deferred from PR #<pr_number> review for TASK-<id>.
 
 Original comment: <comment text>
@@ -168,12 +168,12 @@ Reason deferred: <why this can wait>', 'To Do', 'Low', '<domain>', datetime('now
 
     Update task status:
     ```bash
-    .claude/bin/tusk "UPDATE tasks SET status = 'Done', closed_reason = 'completed', updated_at = datetime('now') WHERE id = <id>"
+    tusk "UPDATE tasks SET status = 'Done', closed_reason = 'completed', updated_at = datetime('now') WHERE id = <id>"
     ```
 
 14. **Check for newly unblocked tasks**:
     ```bash
-    .claude/bin/tusk -header -column "
+    tusk -header -column "
     SELECT t.id, t.summary, t.priority
     FROM tasks t
     JOIN task_dependencies d ON t.id = d.task_id
@@ -186,7 +186,7 @@ Reason deferred: <why this can wait>', 'To Do', 'Low', '<domain>', datetime('now
 When called with `done <id>`:
 
 ```bash
-.claude/bin/tusk "UPDATE tasks SET status = 'Done', closed_reason = 'completed', updated_at = datetime('now') WHERE id = <id>"
+tusk "UPDATE tasks SET status = 'Done', closed_reason = 'completed', updated_at = datetime('now') WHERE id = <id>"
 ```
 
 Then show newly unblocked tasks.
@@ -196,7 +196,7 @@ Then show newly unblocked tasks.
 When called with `view <id>`:
 
 ```bash
-.claude/bin/tusk -header -column "SELECT * FROM tasks WHERE id = <id>"
+tusk -header -column "SELECT * FROM tasks WHERE id = <id>"
 ```
 
 ### List Top N Ready Tasks
@@ -204,7 +204,7 @@ When called with `view <id>`:
 When called with `list <n>` or just a number:
 
 ```bash
-.claude/bin/tusk -header -column "
+tusk -header -column "
 SELECT t.id, t.summary, t.priority, t.domain, t.assignee
 FROM tasks t
 WHERE t.status = 'To Do'
@@ -231,7 +231,7 @@ When called with `assignee <value>`: Get next ready task for that assignee only.
 When called with `blocked`:
 
 ```bash
-.claude/bin/tusk -header -column "
+tusk -header -column "
 SELECT t.id, t.summary, t.priority,
   (SELECT GROUP_CONCAT(d.depends_on_id) FROM task_dependencies d WHERE d.task_id = t.id) as blocked_by
 FROM tasks t
@@ -250,7 +250,7 @@ ORDER BY t.id
 When called with `wip` or `in-progress`:
 
 ```bash
-.claude/bin/tusk -header -column "SELECT id, summary, priority, domain, assignee, github_pr FROM tasks WHERE status = 'In Progress'"
+tusk -header -column "SELECT id, summary, priority, domain, assignee, github_pr FROM tasks WHERE status = 'In Progress'"
 ```
 
 ### Preview Next Task (without starting)
@@ -258,7 +258,7 @@ When called with `wip` or `in-progress`:
 When called with `preview`: Show the next ready task but do NOT start working on it.
 
 ```bash
-.claude/bin/tusk -header -column "
+tusk -header -column "
 SELECT t.id, t.summary, t.priority, t.domain, t.assignee, t.description
 FROM tasks t
 WHERE t.status = 'To Do'
@@ -289,7 +289,7 @@ LIMIT 1;
 
 ## Canonical Values
 
-Run `.claude/bin/tusk config` to see all valid values for this project. Using non-canonical values will be rejected by SQLite triggers.
+Run `tusk config` to see all valid values for this project. Using non-canonical values will be rejected by SQLite triggers.
 
 ### Closed Reason (set when status = Done)
 `completed`, `expired`, `wont_do`, `duplicate`

--- a/skills/tasks/SKILL.md
+++ b/skills/tasks/SKILL.md
@@ -13,7 +13,7 @@ Opens the project task database (via `tusk` CLI) in DB Browser for SQLite for vi
 When this skill is invoked, run:
 
 ```bash
-open -a "DB Browser for SQLite" "$(.claude/bin/tusk path)"
+open -a "DB Browser for SQLite" "$(tusk path)"
 ```
 
 Then confirm to the user that the database has been opened in DB Browser for SQLite.
@@ -23,5 +23,5 @@ Then confirm to the user that the database has been opened in DB Browser for SQL
 Before opening, show a quick summary:
 
 ```bash
-.claude/bin/tusk "SELECT status, COUNT(*) as count FROM tasks GROUP BY status ORDER BY count DESC"
+tusk "SELECT status, COUNT(*) as count FROM tasks GROUP BY status ORDER BY count DESC"
 ```

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -6,7 +6,7 @@
 #   cd /path/to/your/project
 #   /path/to/tusker/uninstall.sh
 # What it removes:
-#   1. .claude/bin/tusk + config.default.json
+#   1. tusk + config.default.json
 #   2. .claude/skills/{check-dupes,groom-backlog,manage-dependencies,next-task,tasks}
 #   3. scripts/check_duplicates.py, scripts/manage_dependencies.py
 #   4. tusk/ directory (database + config) — requires --delete-data flag
@@ -74,7 +74,7 @@ rmdir_if_empty() {
 }
 
 # ── 1. Remove bin files ──────────────────────────────────────────────
-remove_file ".claude/bin/tusk"
+remove_file "tusk"
 remove_file ".claude/bin/config.default.json"
 rmdir_if_empty ".claude/bin"
 


### PR DESCRIPTION
## Summary
- Replaced all `.claude/bin/tusk` references with `tusk` across 9 files (skills, scripts, install/uninstall, docs)
- Python scripts now call `subprocess.check_output(["tusk", "path"])` instead of the full `.claude/bin/tusk` path
- Updated install.sh to copy the binary to the repo root as `tusk` instead of `.claude/bin/tusk`

## Test plan
- [ ] Verify `tusk` resolves correctly when called from project root
- [ ] Run `install.sh` in a test project and confirm `tusk` is placed correctly
- [ ] Run `uninstall.sh` and confirm cleanup works

🤖 Generated with [Claude Code](https://claude.com/claude-code)