### PR TITLE
[TASK-3] Externalize model pricing into pricing.json

### DIFF
--- a/bin/tusk
+++ b/bin/tusk
@@ -458,6 +458,7 @@ cmd_upgrade() {
   done
   cp "$src/VERSION" "$SCRIPT_DIR/VERSION"
   cp "$src/config.default.json" "$SCRIPT_DIR/config.default.json"
+  cp "$src/pricing.json" "$SCRIPT_DIR/pricing.json"
   echo "  Updated CLI and support files"
 
   # Copy skills

--- a/install.sh
+++ b/install.sh
@@ -53,6 +53,9 @@ echo "  Installed .claude/bin/config.default.json"
 cp "$SCRIPT_DIR/VERSION" "$REPO_ROOT/.claude/bin/VERSION"
 echo "  Installed .claude/bin/VERSION"
 
+cp "$SCRIPT_DIR/pricing.json" "$REPO_ROOT/.claude/bin/pricing.json"
+echo "  Installed .claude/bin/pricing.json"
+
 # ── 3. Copy skills ───────────────────────────────────────────────────
 for skill_dir in "$SCRIPT_DIR"/skills/*/; do
   skill_name="$(basename "$skill_dir")"

--- a/pricing.json
+++ b/pricing.json
@@ -1,0 +1,41 @@
+{
+  "models": {
+    "claude-opus-4-6": {
+      "input": 5.00,
+      "cache_write": 10.00,
+      "cache_read": 0.50,
+      "output": 25.00
+    },
+    "claude-opus-4-5": {
+      "input": 5.00,
+      "cache_write": 10.00,
+      "cache_read": 0.50,
+      "output": 25.00
+    },
+    "claude-sonnet-4-5": {
+      "input": 3.00,
+      "cache_write": 6.00,
+      "cache_read": 0.30,
+      "output": 15.00
+    },
+    "claude-sonnet-4": {
+      "input": 3.00,
+      "cache_write": 6.00,
+      "cache_read": 0.30,
+      "output": 15.00
+    },
+    "claude-haiku-4-5": {
+      "input": 1.00,
+      "cache_write": 2.00,
+      "cache_read": 0.10,
+      "output": 5.00
+    }
+  },
+  "aliases": {
+    "claude-opus-4-6-20250918": "claude-opus-4-6",
+    "claude-opus-4-5-20250929": "claude-opus-4-5",
+    "claude-sonnet-4-5-20250929": "claude-sonnet-4-5",
+    "claude-sonnet-4-20250514": "claude-sonnet-4",
+    "claude-haiku-4-5-20251001": "claude-haiku-4-5"
+  }
+}


### PR DESCRIPTION
## Summary
- Moved hardcoded `PRICING` and `MODEL_ALIASES` dicts from `bin/tusk-session-stats.py` into a standalone `pricing.json` data file
- Script now loads pricing at runtime via `load_pricing()`, resolving the file next to the script (installed layout) or in the parent directory (source repo layout)
- Updated `install.sh` and `cmd_upgrade()` to copy `pricing.json` alongside other support files

## Test plan
- [x] Smoke-tested `load_pricing()` in source repo layout — all models and aliases resolve correctly
- [ ] Verify `tusk session-stats` still computes costs correctly with a real transcript
- [ ] Verify `install.sh` copies `pricing.json` to `.claude/bin/`
- [ ] Verify `tusk upgrade` copies `pricing.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)