### PR TITLE
[TASK-18] Document SQL operator gotcha (use <> not !=) in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -185,4 +185,5 @@ Commit the bump in the same branch as the feature — not as a separate PR. The 
 - Deferred tasks from PR reviews get `[Deferred]` prefix and 60-day `expires_at`
 - Always run `/check-dupes` before inserting new tasks
 - Dependencies use DFS cycle detection in Python; SQLite CHECK prevents self-loops
+- In SQL passed through bash, use `<>` instead of `!=` for not-equal comparisons — `!=` can cause parse errors due to shell history expansion (`!` is special in bash)
 - Skills are discovered at Claude Code session startup — after installing or adding a new skill, you must start a new session before invoking it with `/skill-name`


### PR DESCRIPTION
## Summary
- Adds a Key Conventions bullet to CLAUDE.md explaining that SQL passed through bash should use `<>` instead of `!=` for not-equal comparisons, since bash history expansion treats `!` as special and can cause parse errors.

## Notes
- Several existing skills (`groom-backlog`, `reconfigure`, `next-task`) currently use `!=` in their SQL examples. These should be updated in a follow-up task to match the new convention.
- No VERSION bump needed — this is a CLAUDE.md-only change that stays in the repo.

## Test plan
- [ ] Verify the new bullet renders correctly in CLAUDE.md
- [ ] Confirm no other files were modified

🤖 Generated with [Claude Code](https://claude.com/claude-code)