### PR TITLE
[TASK-50] Add git remote set-head origin --auto to /next-task default branch detection

### DIFF
--- a/skills/next-task/SKILL.md
+++ b/skills/next-task/SKILL.md
@@ -90,6 +90,7 @@ When called with a task ID (e.g., `/next-task 6`), begin the full development wo
    - Format: `feature/TASK-<id>-brief-description`
    - First, detect the repo's default branch:
      ```bash
+     git remote set-head origin --auto 2>/dev/null
      DEFAULT_BRANCH=$(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's@^refs/remotes/origin/@@')
      if [ -z "$DEFAULT_BRANCH" ]; then
        DEFAULT_BRANCH=$(gh repo view --json defaultBranchRef -q .defaultBranchRef.name 2>/dev/null || echo "main")
@@ -215,6 +216,7 @@ Reason deferred: <why this can wait>"), 'To Do', 'Low', '<domain>', datetime('no
 
     Close the session with timing and diff stats:
     ```bash
+    git remote set-head origin --auto 2>/dev/null
     DEFAULT_BRANCH=$(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's@^refs/remotes/origin/@@')
     if [ -z "$DEFAULT_BRANCH" ]; then
       DEFAULT_BRANCH=$(gh repo view --json defaultBranchRef -q .defaultBranchRef.name 2>/dev/null || echo "main")


### PR DESCRIPTION
## Summary

- Adds `git remote set-head origin --auto 2>/dev/null` before the `git symbolic-ref refs/remotes/origin/HEAD` check in the `/next-task` skill
- Applied to both occurrences: step 6 (feature branch creation) and step 16 (session close stats)
- Ensures `origin/HEAD` stays current if the repo's default branch changes on GitHub, preventing feature branches from being created off the wrong base

## Test plan

- [ ] Verify `/next-task` still correctly detects the default branch after the change
- [ ] Confirm `git remote set-head origin --auto` runs silently (stderr suppressed) when offline or when remote is unreachable

🤖 Generated with [Claude Code](https://claude.com/claude-code)