### PR TITLE
[TASK-61] Remove duplicate function definitions in tusk-dupes.py

### DIFF
--- a/bin/tusk-dupes.py
+++ b/bin/tusk-dupes.py
@@ -133,16 +133,6 @@ def similarity_cached(norm_a: str, norm_b: str) -> float:
     return combined_similarity(norm_a, norm_b)
 
 
-def build_norm_cache(tasks) -> dict[int, str]:
-    """Pre-compute normalized summaries for a list of tasks."""
-    return {t["id"]: normalize_summary(t["summary"]) for t in tasks}
-
-
-def similarity_cached(norm_a: str, norm_b: str) -> float:
-    """Compute similarity between two pre-normalized strings."""
-    return SequenceMatcher(None, norm_a, norm_b).ratio()
-
-
 def get_open_tasks(
     conn: sqlite3.Connection,
     domain: str | None = None,


### PR DESCRIPTION
## Summary
- `build_norm_cache` and `similarity_cached` were each defined twice in `bin/tusk-dupes.py` (lines ~126-133 and ~136-143)
- The second `similarity_cached` used raw `SequenceMatcher` instead of `combined_similarity`, so the Jaccard token-level scoring was never actually invoked by `cmd_check`, `cmd_scan`, or `cmd_similar`
- Removed the shadowing duplicate definitions, keeping the correct first versions that use `combined_similarity` (blended char + Jaccard scorer)

## Test plan
- [ ] Run `tusk dupes check "<summary>" --debug` and verify `combined_similarity` is used (debug output should show blended scores)
- [ ] Run `tusk dupes scan --debug` and verify duplicate pair scoring uses the blended similarity
- [ ] Verify no duplicate function definitions exist: `python3 -c "import ast, collections; tree = ast.parse(open('bin/tusk-dupes.py').read()); dupes = [n for n, c in collections.Counter(node.name for node in ast.walk(tree) if isinstance(node, ast.FunctionDef)).items() if c > 1]; print('PASS' if not dupes else f'FAIL: {dupes}')"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)