### PR TITLE
[TASK-66] Fix stale /analysis-to-tasks reference in check-dupes

### DIFF
--- a/skills/check-dupes/SKILL.md
+++ b/skills/check-dupes/SKILL.md
@@ -28,7 +28,7 @@ Pre-insert gate. Checks if a summary is a duplicate of any open task.
 tusk dupes check "<summary>" --domain <domain>
 ```
 
-**When to use:** Before every `INSERT INTO tasks` — in `/next-task`, `/analysis-to-tasks`, or any manual task creation.
+**When to use:** Before every `INSERT INTO tasks` — in `/next-task`, `/create-task`, or any manual task creation.
 
 ### `scan`
 


### PR DESCRIPTION
## Summary
- Replaced stale `/analysis-to-tasks` reference with `/create-task` in `skills/check-dupes/SKILL.md` line 31
- The skill was previously renamed but this reference was missed

## Test plan
- [ ] Verify the check-dupes SKILL.md references `/create-task` instead of `/analysis-to-tasks`
- [ ] Confirm no other stale references exist

🤖 Generated with [Claude Code](https://claude.com/claude-code)