### PR TITLE
[TASK-91] Fix stale scripts/ reference in install.sh header comment

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -7,9 +7,9 @@
 #   /path/to/tusker/install.sh
 #
 # What it does:
-#   1. Copies bin/tusk + support files → .claude/bin/
-#   2. Copies skills/*                 → .claude/skills/*
-#   3. Copies scripts/*                → scripts/*  (creates if needed)
+#   1. Copies bin/tusk + Python scripts → .claude/bin/
+#   2. Copies config, VERSION, pricing  → .claude/bin/
+#   3. Copies skills/*                  → .claude/skills/*
 #   4. Installs SessionStart hook to put .claude/bin on PATH
 #   5. Runs tusk init + migrate
 #   6. Prints next steps


### PR DESCRIPTION
## Summary
- Updated the header comment in `install.sh` to match the actual install steps
- Removed stale step 3 ("Copies scripts/* → scripts/*") which was eliminated in TASK-35
- Renumbered and relabeled steps to reflect current flow: bin+Python scripts, config/VERSION/pricing, skills, PATH hook, init+migrate, next steps

## Test plan
- [ ] Verify the 6 numbered comment steps match the 6 `# ── N.` section headers in the script body

🤖 Generated with [Claude Code](https://claude.com/claude-code)