### PR TITLE
[TASK-120] Add changelog update convention to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -305,6 +305,10 @@ echo 14 > VERSION
 
 Commit the bump in the same branch as the feature — not as a separate PR. The commit message can be standalone (`Bump VERSION to 14`) or folded into the feature commit.
 
+### Changelog
+
+When bumping `VERSION`, also update `CHANGELOG.md` in the same commit. Add an entry under a new `## [<version>] - <YYYY-MM-DD>` heading describing what changed. Use the [Keep a Changelog](https://keepachangelog.com/) categories (`Added`, `Changed`, `Fixed`, `Removed`) and keep descriptions to one line each.
+
 ## Key Conventions
 
 - All DB access goes through `bin/tusk`, never raw `sqlite3`


### PR DESCRIPTION
## Summary
- Adds a **Changelog** subsection to the VERSION Bumps section in CLAUDE.md
- Documents that `CHANGELOG.md` must be updated in the same commit as the `VERSION` bump
- Specifies use of Keep a Changelog categories (Added, Changed, Fixed, Removed)

## Test plan
- [ ] Verify the new subsection renders correctly in CLAUDE.md
- [ ] Confirm the convention is clear and actionable

🤖 Generated with [Claude Code](https://claude.com/claude-code)