### PR TITLE
[TASK-139] Add GitHub Action to auto-create releases on VERSION bump

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,58 @@
+name: Auto-release on VERSION bump
+
+on:
+  push:
+    branches: [main]
+    paths: [VERSION]
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Read version
+        id: version
+        run: |
+          VERSION=$(cat VERSION | tr -d '[:space:]')
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "tag=v$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Check if release already exists
+        id: check
+        run: |
+          if gh release view "v${{ steps.version.outputs.version }}" >/dev/null 2>&1; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract changelog entry
+        if: steps.check.outputs.exists == 'false'
+        id: changelog
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          # Extract the section for this version from CHANGELOG.md
+          # Matches from "## [<version>]" until the next "## [" or end of file
+          BODY=$(sed -n "/^## \[$VERSION\]/,/^## \[/{ /^## \[$VERSION\]/d; /^## \[/d; p; }" CHANGELOG.md)
+          if [ -z "$BODY" ]; then
+            BODY="Release v$VERSION"
+          fi
+          # Write to file to preserve newlines
+          echo "$BODY" > /tmp/release-notes.md
+
+      - name: Create release
+        if: steps.check.outputs.exists == 'false'
+        run: |
+          gh release create "${{ steps.version.outputs.tag }}" \
+            --title "${{ steps.version.outputs.tag }}" \
+            --notes-file /tmp/release-notes.md
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Adds a GitHub Actions workflow (`.github/workflows/release.yml`) that automatically creates a tagged GitHub Release whenever a push to `main` changes the `VERSION` file
- Extracts release notes from the matching `CHANGELOG.md` section
- Skips release creation if the tag already exists, preventing duplicates on re-runs

## Test plan
- [ ] Merge this PR and then merge another PR that bumps VERSION — verify a new GitHub Release is created automatically
- [ ] Verify the release tag matches `v<version>` format
- [ ] Verify release notes are extracted from the correct CHANGELOG.md section
- [ ] Push to main without changing VERSION — verify no release is created
- [ ] Manually re-run the workflow for an existing version — verify no duplicate release is created

🤖 Generated with [Claude Code](https://claude.com/claude-code)