### PR TITLE
[TASK-143] Add PreToolUse hook to block raw sqlite3 usage

### DIFF
--- a/.claude/hooks/block-raw-sqlite.sh
+++ b/.claude/hooks/block-raw-sqlite.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+# PreToolUse hook: blocks direct sqlite3 invocations.
+# All DB access should go through bin/tusk.
+
+# Read JSON from stdin
+input=$(cat)
+
+# Extract the command from tool_input.command
+command=$(echo "$input" | python3 -c "
+import sys, json
+data = json.load(sys.stdin)
+print(data.get('tool_input', {}).get('command', ''))
+" 2>/dev/null)
+
+# Check if sqlite3 is invoked in command position (after start-of-line,
+# pipe, semicolon, &&, ||, or $() — not inside quoted strings.
+if echo "$command" | grep -qE '(^|[|;&]|&&|\|\||\$\()\s*sqlite3\b'; then
+  echo "Use bin/tusk instead of raw sqlite3. See CLAUDE.md for details."
+  exit 2
+fi
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -9,6 +9,17 @@
           }
         ]
       }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": ".claude/hooks/block-raw-sqlite.sh"
+          }
+        ]
+      }
     ]
   }
 }


### PR DESCRIPTION
## Summary
- Adds `.claude/hooks/block-raw-sqlite.sh` — a PreToolUse(Bash) hook that parses `tool_input.command` from stdin JSON and blocks direct `sqlite3` invocations with exit code 2
- Uses a command-position regex so `sqlite3` in commit messages or quoted strings is not falsely blocked
- Registers the hook in `.claude/settings.json` under PreToolUse with a Bash matcher
- Commands routed through `bin/tusk` are unaffected

## Test plan
- [x] Direct `sqlite3 db "query"` commands are blocked with clear message
- [x] `tusk "SELECT ..."` and `bin/tusk ...` commands pass through
- [x] Non-sqlite commands (git, etc.) pass through
- [x] Malformed/empty JSON input is handled gracefully (exits 0)
- [x] Convention lint passes with no violations

🤖 Generated with [Claude Code](https://claude.com/claude-code)