### PR TITLE
[TASK-144] Add PostToolUse hook for auto-lint on skill/script changes

### DIFF
--- a/.claude/hooks/auto-lint.sh
+++ b/.claude/hooks/auto-lint.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+# PostToolUse hook: runs tusk lint when skills/ or bin/ files are edited.
+# Non-blocking — always exits 0. Violations surface as additionalContext.
+
+input=$(cat)
+
+# Extract the file path from tool_input
+file_path=$(echo "$input" | python3 -c "
+import sys, json
+data = json.load(sys.stdin)
+print(data.get('tool_input', {}).get('file_path', ''))
+" 2>/dev/null)
+
+[ -z "$file_path" ] && exit 0
+
+# Resolve repo root for relative-path matching
+repo_root=$(git rev-parse --show-toplevel 2>/dev/null) || exit 0
+
+# Strip repo root to get the relative path
+rel_path="${file_path#"$repo_root"/}"
+
+# Only lint when the file is under skills/ or bin/
+case "$rel_path" in
+  skills/*|bin/*) ;;
+  *) exit 0 ;;
+esac
+
+# Run tusk lint and capture output; use exit code to detect violations
+lint_output=$(tusk lint 2>&1)
+lint_rc=$?
+
+# Exit code 0 = no violations, nothing to report
+[ "$lint_rc" -eq 0 ] && exit 0
+
+# Return violations as additionalContext
+python3 -c "
+import json, sys
+ctx = sys.argv[1]
+print(json.dumps({
+    'hookSpecificOutput': {
+        'hookEventName': 'PostToolUse',
+        'additionalContext': 'tusk lint found convention violations after editing ' + sys.argv[2] + ':\n' + ctx
+    }
+}))
+" "$lint_output" "$rel_path"
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -20,6 +20,18 @@
           }
         ]
       }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": ".claude/hooks/auto-lint.sh",
+            "timeout": 30
+          }
+        ]
+      }
     ]
   }
 }


### PR DESCRIPTION
## Summary
- Adds `.claude/hooks/auto-lint.sh` — a PostToolUse hook that runs `tusk lint` automatically when Edit or Write touches files under `skills/` or `bin/`
- Lint violations are returned as `additionalContext` JSON so Claude sees them immediately instead of waiting for manual `/lint-conventions` invocation
- Hook is non-blocking (always exits 0); files outside `skills/` and `bin/` are silently skipped

## Test plan
- [x] Hook fires on Edit/Write for `skills/` files → runs lint, no output when clean
- [x] Hook fires on Edit/Write for `bin/` files → runs lint, no output when clean
- [x] Hook outputs JSON with `additionalContext` when lint finds violations
- [x] Hook always exits 0 (non-blocking) even with violations
- [x] Files outside `skills/` and `bin/` skip lint entirely (no output, exit 0)
- [x] Empty/missing `tool_input` handled gracefully (exit 0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)