### PR TITLE
[TASK-145] Add PreToolUse hook for duplicate gate before task INSERT

### DIFF
--- a/.claude/hooks/dupe-gate.sh
+++ b/.claude/hooks/dupe-gate.sh
@@ -1,0 +1,126 @@
+#!/bin/bash
+# PreToolUse hook: blocks INSERT INTO tasks when a duplicate summary exists.
+# Extracts the summary from the SQL, runs tusk dupes check, exits 2 on match.
+
+# Read JSON from stdin
+input=$(cat)
+
+# Extract the command from tool_input.command
+command=$(echo "$input" | python3 -c "
+import sys, json
+data = json.load(sys.stdin)
+print(data.get('tool_input', {}).get('command', ''))
+" 2>/dev/null)
+
+# Quick check: skip if not an INSERT INTO tasks
+echo "$command" | grep -qiE 'INSERT[[:space:]]+INTO[[:space:]]+tasks[[:space:]]*\(' || exit 0
+
+# Extract the summary value from the INSERT statement
+summary=$(HOOK_CMD="$command" python3 << 'PYEOF'
+import os, re, sys
+
+cmd = os.environ.get("HOOK_CMD", "")
+
+# Extract column list from INSERT INTO tasks (col1, col2, ...)
+m = re.search(r'INSERT\s+INTO\s+tasks\s*\(([^)]+)\)', cmd, re.IGNORECASE | re.DOTALL)
+if not m:
+    sys.exit(1)
+
+cols = [c.strip() for c in m.group(1).split(',')]
+try:
+    idx = cols.index('summary')
+except ValueError:
+    sys.exit(1)
+
+# Find VALUES clause
+rest = cmd[m.end():]
+vm = re.search(r'VALUES\s*\(', rest, re.IGNORECASE | re.DOTALL)
+if not vm:
+    sys.exit(1)
+
+# Parse value list respecting quotes and parentheses
+vstr = rest[vm.end():]
+values = []
+buf = []
+depth = 0
+in_sq = False
+in_dq = False
+i = 0
+
+while i < len(vstr):
+    ch = vstr[i]
+    if ch == '\\' and i + 1 < len(vstr) and not in_sq:
+        buf.append(ch + vstr[i + 1])
+        i += 2
+        continue
+    if ch == "'" and not in_dq:
+        in_sq = not in_sq
+    elif ch == '"' and not in_sq:
+        in_dq = not in_dq
+    elif not in_sq and not in_dq:
+        if ch == '(':
+            depth += 1
+        elif ch == ')':
+            if depth == 0:
+                values.append(''.join(buf).strip())
+                break
+            depth -= 1
+        elif ch == ',' and depth == 0:
+            values.append(''.join(buf).strip())
+            buf = []
+            i += 1
+            continue
+    buf.append(ch)
+    i += 1
+
+if idx >= len(values):
+    sys.exit(1)
+
+val = values[idx]
+
+# Pattern 1: $(tusk sql-quote "...")
+sm = re.search(r'\$\(tusk\s+sql-quote\s+"([^"]*)"\)', val)
+if sm:
+    print(sm.group(1))
+    sys.exit(0)
+
+# Pattern 2: Single-quoted SQL string '...'
+sm = re.match(r"^'(.*)'$", val, re.DOTALL)
+if sm:
+    print(sm.group(1).replace("''", "'"))
+    sys.exit(0)
+
+sys.exit(1)
+PYEOF
+)
+py_rc=$?
+
+# If extraction failed or no summary found, allow the command
+if [ "$py_rc" -ne 0 ] || [ -z "$summary" ]; then
+  exit 0
+fi
+
+# Run duplicate check
+dupe_output=$(tusk dupes check "$summary" --json 2>&1)
+dupe_rc=$?
+
+# Exit code 1 from tusk dupes = duplicates found
+if [ "$dupe_rc" -eq 1 ]; then
+  echo "Duplicate task detected! Similar tasks found for summary:"
+  echo "  '$summary'"
+  echo ""
+  echo "$dupe_output" | python3 -c "
+import sys, json
+try:
+    data = json.load(sys.stdin)
+    for d in data.get('duplicates', []):
+        print(f\"  TASK-{d['id']} ({d['similarity']:.0%} match): {d['summary']}\")
+except:
+    pass
+" 2>/dev/null
+  echo ""
+  echo "Run /check-dupes to review, or close the duplicate first."
+  exit 2
+fi
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -19,6 +19,16 @@
             "command": ".claude/hooks/block-raw-sqlite.sh"
           }
         ]
+      },
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": ".claude/hooks/dupe-gate.sh",
+            "timeout": 15
+          }
+        ]
       }
     ],
     "PostToolUse": [


### PR DESCRIPTION
## Summary

- Adds `dupe-gate.sh` PreToolUse hook that intercepts `INSERT INTO tasks` commands, extracts the summary from the SQL, and runs `tusk dupes check` to block duplicates before they're inserted
- Parses both `$(tusk sql-quote "...")` and single-quoted summary values with a position-aware VALUES clause parser
- Registered in `.claude/settings.json` with 15-second timeout; gracefully passes through when extraction fails or the command isn't a task INSERT

## Test plan

- [x] INSERT with duplicate summary → blocked (exit 2) with similarity scores
- [x] INSERT with unique summary → allowed (exit 0)
- [x] Non-INSERT tusk command (SELECT) → allowed (exit 0)
- [x] INSERT into other tables (task_dependencies) → allowed (exit 0)
- [x] Single-quoted summary value → correctly extracted
- [x] INSERT text in commit message → gracefully passes through

🤖 Generated with [Claude Code](https://claude.com/claude-code)