### PR TITLE
[TASK-147] Add PreToolUse hook for SQL != operator detection

### DIFF
--- a/.claude/hooks/block-sql-neq.sh
+++ b/.claude/hooks/block-sql-neq.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+# PreToolUse hook: blocks != in SQL contexts.
+# Shell history expansion breaks != — use <> instead.
+
+# Read JSON from stdin
+input=$(cat)
+
+# Extract the command from tool_input.command
+command=$(echo "$input" | python3 -c "
+import sys, json
+data = json.load(sys.stdin)
+print(data.get('tool_input', {}).get('command', ''))
+" 2>/dev/null)
+
+# Quick exit: no != means nothing to check
+echo "$command" | grep -q '!=' || exit 0
+
+# Only block when tusk is being invoked (the only sanctioned way to run SQL).
+# This avoids false positives on git commits, echo strings, etc. that happen
+# to mention != alongside SQL keywords as documentation text.
+if echo "$command" | grep -qE '(^|[|;&]|&&|\|\||\$\()\s*(bin/)?tusk\b'; then
+  echo "Use <> instead of != in SQL — shell history expansion breaks !=."
+  exit 2
+fi
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -29,6 +29,15 @@
             "timeout": 15
           }
         ]
+      },
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": ".claude/hooks/block-sql-neq.sh"
+          }
+        ]
       }
     ],
     "PostToolUse": [


### PR DESCRIPTION
## Summary
- Adds `block-sql-neq.sh` PreToolUse hook that blocks `!=` in tusk SQL commands, directing users to use `<>` instead
- Shell history expansion treats `!` specially, making `!=` a footgun in bash-executed SQL
- Uses command-position regex for `tusk` detection to avoid false positives on git commits, echo strings, and bash conditionals

## Test plan
- [x] Hook blocks `tusk "SELECT ... WHERE status != 'Done'"` (exit 2)
- [x] Hook blocks `bin/tusk "UPDATE ... WHERE id != 5"` (exit 2)
- [x] Hook blocks piped/chained tusk commands with `!=` (exit 2)
- [x] Hook allows bash conditionals: `[ "$x" != "y" ]` (exit 0)
- [x] Hook allows git commit messages mentioning `!=` (exit 0)
- [x] Hook allows tusk commands using `<>` (exit 0)
- [x] Hook allows Python/echo commands with `!=` (exit 0)
- [x] Hook registered in `.claude/settings.json` under PreToolUse with Bash matcher
- [x] Convention lint passes with no violations

🤖 Generated with [Claude Code](https://claude.com/claude-code)