### PR TITLE
[TASK-166] Add assignee and description to chain scope output

### DIFF
--- a/bin/tusk-chain.py
+++ b/bin/tusk-chain.py
@@ -69,7 +69,7 @@ def cmd_scope(conn: sqlite3.Connection, head_id: int):
     # Fetch task details for all tasks in scope
     placeholders = ",".join("?" * len(task_ids))
     rows = conn.execute(
-        f"SELECT id, summary, status, priority, complexity FROM tasks WHERE id IN ({placeholders})",
+        f"SELECT id, summary, status, priority, complexity, assignee, description FROM tasks WHERE id IN ({placeholders})",
         task_ids,
     ).fetchall()
 
@@ -82,9 +82,11 @@ def cmd_scope(conn: sqlite3.Connection, head_id: int):
         tasks.append({
             "id": tid,
             "summary": row["summary"],
+            "description": row["description"],
             "status": row["status"],
             "priority": row["priority"],
             "complexity": row["complexity"],
+            "assignee": row["assignee"],
             "depth": depth_map[tid],
         })
 


### PR DESCRIPTION
## Summary
- Adds `assignee` and `description` fields to `tusk chain scope` JSON output
- Eliminates supplemental SQL queries needed by consumers like `/run-chain`
- Two-line change in `bin/tusk-chain.py` `cmd_scope()`

## Test plan
- [x] Verified `tusk chain scope <id>` output includes both new fields
- [x] Lint passes on modified files

🤖 Generated with [Claude Code](https://claude.com/claude-code)