### PR TITLE
[TASK-189] Add conditional guard to next-task SUBCOMMANDS.md companion load

### DIFF
--- a/skills/next-task/SKILL.md
+++ b/skills/next-task/SKILL.md
@@ -152,13 +152,13 @@ When called with a task ID (e.g., `/next-task 6`), begin the full development wo
 
 ### Other Subcommands
 
-For `done`, `view`, `list`, `domain`, `assignee`, `blocked`, `wip`, and `preview` subcommands, read the reference file in this skill directory:
+If the user invoked a subcommand (e.g., `/next-task done`, `/next-task list`, `/next-task blocked`), read the reference file:
 
 ```
 Read file: <base_directory>/SUBCOMMANDS.md
 ```
 
-Where `<base_directory>` is the skill base directory shown at the top of this file.
+Skip this section when running the default workflow (no subcommand argument).
 
 ## Canonical Values
 


### PR DESCRIPTION
## Summary
- Restructured the "Other Subcommands" section in `next-task/SKILL.md` to conditionally load `SUBCOMMANDS.md` only when a subcommand is invoked (e.g., `/next-task done`, `/next-task list`)
- The default `/next-task` workflow no longer triggers the companion file load, saving ~1,240 tokens per invocation

## Acceptance Criteria
- [x] next-task/SKILL.md loads SUBCOMMANDS.md only when a subcommand argument is provided
- [x] retro, run-chain, tusk-insights companions already had proper conditional guards (verified, no changes needed)
- [x] Each companion Read instruction is gated behind a conditional
- [ ] Token-audit shows zero UNCONDITIONAL entries — **partially met**: next-task is now conditional, but the audit heuristic still flags false positives for retro, run-chain, and tusk-insights (they use conditional patterns like `→` arrows and `For each category` that the regex doesn't recognize)

## Note on criterion 390
The remaining UNCONDITIONAL flags in `tusk token-audit` are false positives from the 5-line lookback heuristic. The actual skills have proper conditional guards — the audit tool's `CONDITIONAL_KEYWORDS` regex doesn't match their phrasing. Improving the heuristic is a separate task.

## Test plan
- [x] Verified `tusk token-audit` now reports next-task/SUBCOMMANDS.md as `conditional`
- [x] Confirmed the "If the user invoked a subcommand" guard contains keyword `if` within the 5-line window

🤖 Generated with [Claude Code](https://claude.com/claude-code)