### PR TITLE
[TASK-200] Fix lint Rule 5 false positives on SELECT statements

### DIFF
--- a/bin/tusk-lint.py
+++ b/bin/tusk-lint.py
@@ -135,7 +135,7 @@ def rule5_done_without_closed_reason(root):
     exempt = {"bin/tusk-lint.py"}
     done_re = re.compile(r"status\s*=\s*'Done'", re.IGNORECASE)
     # Matches UPDATE or INSERT that would actually *set* the status
-    write_re = re.compile(r"\b(UPDATE|INSERT)\b", re.IGNORECASE)
+    write_re = re.compile(r"(?<!-)\b(UPDATE|INSERT)\b", re.IGNORECASE)
     select_re = re.compile(r"\bSELECT\b", re.IGNORECASE)
 
     for rel, full in find_files(root, ["skills", "scripts", "bin"], [".md", ".sh", ".py"]):
@@ -145,6 +145,11 @@ def rule5_done_without_closed_reason(root):
         for i, (lineno, line) in enumerate(lines):
             if not done_re.search(line):
                 continue
+
+            # Fast path: if the line itself is a SELECT (no write keywords), skip
+            if select_re.search(line) and not write_re.search(line):
+                continue
+
             # Check surrounding context (same line + 15 lines before)
             # to determine the SQL statement type
             context_start = max(0, i - 15)


### PR DESCRIPTION
## Summary
- Fixed Rule 5 ("Done without closed_reason") in `tusk lint` which falsely flagged SELECT queries that reference `status = 'Done'`
- Added a fast-path line check: if the matching line itself contains SELECT and no write keywords, skip immediately
- Added negative lookbehind `(?<!-)` to the write keyword regex so CLI command names like `task-insert` and `task-update` in the context window don't trigger false write detection

## Root cause
The rule checked a 20-line context window for UPDATE/INSERT keywords. Two issues:
1. Natural language "Insert" (e.g., "Insert approved tasks:") in nearby Markdown text matched the write regex
2. CLI command names like `tusk task-insert` also matched

The fix checks the matching line itself first (fast path), and only falls back to context analysis for multi-line SQL statements.

## Test plan
- [x] `tusk lint` passes clean on the actual codebase (previously showed 2 false positives in retro skill files)
- [x] Verified Rule 5 still catches `UPDATE tasks SET status = 'Done'` without `closed_reason`
- [x] Verified Rule 5 correctly skips `SELECT ... WHERE status = 'Done'`

🤖 Generated with [Claude Code](https://claude.com/claude-code)