### PR TITLE
[TASK-210] Show seconds in acceptance criteria timestamps on dashboard

### DIFF
--- a/bin/tusk-dashboard.py
+++ b/bin/tusk-dashboard.py
@@ -98,12 +98,12 @@ def format_duration(seconds) -> str:
 
 
 def format_date(dt_str) -> str:
-    """Format an ISO datetime string as YYYY-MM-DD HH:MM."""
+    """Format an ISO datetime string as YYYY-MM-DD HH:MM:SS."""
     if dt_str is None:
         return '<span class="text-muted-dash">&mdash;</span>'
     try:
         dt = datetime.strptime(dt_str, "%Y-%m-%d %H:%M:%S")
-        return dt.strftime("%Y-%m-%d %H:%M")
+        return dt.strftime("%Y-%m-%d %H:%M:%S")
     except (ValueError, TypeError):
         return esc(dt_str)
 


### PR DESCRIPTION
## Summary
- Changed `format_date()` in `tusk-dashboard.py` to output `%H:%M:%S` instead of `%H:%M`
- Criteria completed in rapid succession within the same minute are now visually distinguishable
- The `sort_completed` data attribute already used the full timestamp with seconds, so sorting was unaffected

## Test plan
- [ ] Run `tusk dashboard` and verify acceptance criteria timestamps show seconds (HH:MM:SS)
- [ ] Verify task-level created_at and updated_at columns also show seconds
- [ ] Confirm sorting by completed_at still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)