### PR TITLE
[TASK-211] Include milliseconds in acceptance criteria completed_at display in dashboard

### DIFF
--- a/bin/tusk-dashboard.py
+++ b/bin/tusk-dashboard.py
@@ -98,10 +98,13 @@ def format_duration(seconds) -> str:
 
 
 def format_date(dt_str) -> str:
-    """Format an ISO datetime string as YYYY-MM-DD HH:MM:SS."""
+    """Format an ISO datetime string as YYYY-MM-DD HH:MM:SS[.mmm]."""
     if dt_str is None:
         return '<span class="text-muted-dash">&mdash;</span>'
     try:
+        if '.' in dt_str:
+            dt = datetime.strptime(dt_str, "%Y-%m-%d %H:%M:%S.%f")
+            return dt.strftime("%Y-%m-%d %H:%M:%S.") + f"{dt.microsecond // 1000:03d}"
         dt = datetime.strptime(dt_str, "%Y-%m-%d %H:%M:%S")
         return dt.strftime("%Y-%m-%d %H:%M:%S")
     except (ValueError, TypeError):


### PR DESCRIPTION
## Summary
- Updated `format_date()` in `bin/tusk-dashboard.py` to parse and display milliseconds when present in timestamps
- Acceptance criteria `completed_at` badges now show sub-second precision (e.g., `2026-02-20 14:30:45.123`)
- Timestamps without fractional seconds continue to display as before

## Test plan
- [x] Verified millisecond parsing with `.%f` format strings
- [x] Verified timestamps without milliseconds still render correctly
- [x] Verified `None` values produce the dash placeholder without errors
- [x] Generated dashboard HTML and confirmed it opens in browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)