### PR TITLE
[TASK-215] Run WSJF scoring automatically inside tusk task-insert

### DIFF
--- a/bin/tusk-task-insert.py
+++ b/bin/tusk-task-insert.py
@@ -300,8 +300,12 @@ def main(argv: list[str]) -> int:
     except sqlite3.Error as e:
         conn.rollback()
         print(f"Database error: {e}", file=sys.stderr)
-        conn.close()
         return 2
+    finally:
+        conn.close()
+
+    # Run WSJF scoring so the new task gets a priority_score immediately
+    subprocess.run(["tusk", "wsjf"], capture_output=True)
 
     result = {
         "task_id": task_id,
@@ -309,7 +313,6 @@ def main(argv: list[str]) -> int:
         "criteria_ids": criteria_ids,
     }
     print(json.dumps(result, indent=2))
-    conn.close()
     return 0
 
 

--- a/skills/create-task/SKILL.md
+++ b/skills/create-task/SKILL.md
@@ -166,16 +166,6 @@ Read file: <base_directory>/DEPENDENCIES.md
 
 Then follow its instructions.
 
-## Step 7b: Recompute Priority Scores
-
-After all insertions and dependency proposals are complete, recompute WSJF scores so the new tasks are immediately ranked in the backlog:
-
-```bash
-tusk wsjf
-```
-
-This is a single bulk UPDATE that takes milliseconds. Run it once — not per-task.
-
 ## Step 8: Report Results
 
 After processing all tasks, show a summary:

--- a/skills/groom-backlog/SKILL.md
+++ b/skills/groom-backlog/SKILL.md
@@ -190,15 +190,9 @@ Read file: <base_directory>/REFERENCE.md
 
 Follow Steps 6b–6d from the reference, then continue to Step 7 below.
 
-## Step 7: Compute Priority Scores and Final Report
+## Step 7: Final Report
 
-After all grooming changes and sizing are complete, run the WSJF scoring command:
-
-```bash
-tusk wsjf
-```
-
-Then generate the summary report:
+Generate the summary report:
 
 ```markdown
 ## Backlog Grooming Complete


### PR DESCRIPTION
## Summary
- Adds automatic `tusk wsjf` call in `tusk-task-insert.py` after successful task insertion, so every newly created task gets a non-zero `priority_score` immediately
- Removes the now-redundant explicit `tusk wsjf` steps from `/create-task` (Step 7b) and `/groom-backlog` (Step 7)
- Standalone `tusk wsjf` command remains available for manual use

## Test plan
- [ ] Run `tusk task-insert` and verify the returned task has a non-zero `priority_score` in the DB
- [ ] Run `tusk wsjf` independently and confirm it still works
- [ ] Invoke `/create-task` and verify it no longer includes a `tusk wsjf` step

🤖 Generated with [Claude Code](https://claude.com/claude-code)