### PR TITLE
[TASK-216] Run WSJF scoring automatically after task-update priority/complexity changes

### DIFF
--- a/bin/tusk-task-update.py
+++ b/bin/tusk-task-update.py
@@ -30,6 +30,7 @@ Exit codes:
 
 import json
 import sqlite3
+import subprocess
 import sys
 
 
@@ -170,6 +171,10 @@ def main(argv: list[str]) -> int:
         print(f"Database error: {e}", file=sys.stderr)
         conn.close()
         return 2
+
+    # Re-score WSJF if priority or complexity changed (inputs to the formula)
+    if "priority" in updates or "complexity" in updates:
+        subprocess.run(["tusk", "wsjf"], capture_output=True)
 
     # Re-fetch and return updated task
     updated_task = conn.execute("SELECT * FROM tasks WHERE id = ?", (task_id,)).fetchone()


### PR DESCRIPTION
## Summary

`tusk task-update` now automatically runs `tusk wsjf` when `--priority` or `--complexity` flags are present — the two inputs to the WSJF formula. This mirrors the behavior already added to `tusk task-insert` in TASK-215, ensuring `priority_score` stays current after field updates (e.g., during grooming).

## Changes

- Added `import subprocess` to `bin/tusk-task-update.py`
- Added conditional `subprocess.run(["tusk", "wsjf"], capture_output=True)` after successful UPDATE when priority or complexity changed

## Test plan

- [x] Verified changing priority from Medium → High updates `priority_score` (70 → 90)
- [x] Verified restoring priority back to Medium restores `priority_score` (90 → 70)
- [x] Lint passes with no violations