### PR TITLE
[TASK-219] Add committed_at timestamp to acceptance_criteria with schema migration 9→10

### DIFF
--- a/bin/tusk
+++ b/bin/tusk
@@ -468,6 +468,7 @@ CREATE TABLE acceptance_criteria (
     verification_spec TEXT,
     verification_result TEXT,
     commit_hash TEXT,
+    committed_at TEXT,
     created_at TEXT DEFAULT (datetime('now')),
     updated_at TEXT DEFAULT (datetime('now')),
     FOREIGN KEY (task_id) REFERENCES tasks(id) ON DELETE CASCADE,
@@ -501,7 +502,7 @@ EB_SCHEMA
   fi
 
   # Set schema version so fresh DBs never need migration
-  sqlite3 "$DB_PATH" "PRAGMA user_version = 9;"
+  sqlite3 "$DB_PATH" "PRAGMA user_version = 10;"
 
   echo "Initialized task database at $DB_PATH"
 }
@@ -793,6 +794,21 @@ cmd_migrate() {
       echo "  Migration 9: added commit_hash column to acceptance_criteria"
     else
       sqlite3 "$DB_PATH" "PRAGMA user_version = 9;"
+    fi
+  fi
+
+  # Migration 9→10: add committed_at column to acceptance_criteria
+  if [[ "$current" -lt 10 ]]; then
+    local has_committed_at
+    has_committed_at="$(sqlite3 "$DB_PATH" "SELECT COUNT(*) FROM pragma_table_info('acceptance_criteria') WHERE name = 'committed_at';")"
+    if [[ "$has_committed_at" -eq 0 ]]; then
+      sqlite3 "$DB_PATH" "
+        ALTER TABLE acceptance_criteria ADD COLUMN committed_at TEXT;
+        PRAGMA user_version = 10;
+      "
+      echo "  Migration 10: added committed_at column to acceptance_criteria"
+    else
+      sqlite3 "$DB_PATH" "PRAGMA user_version = 10;"
     fi
   fi
 


### PR DESCRIPTION
## Summary
- Adds `committed_at TEXT` column to `acceptance_criteria` via schema migration 9→10
- `tusk criteria done` now captures the git commit author date (`git log -1 --format=%cI HEAD`) alongside the existing `commit_hash`
- `capture_criterion_cost` uses `committed_at` (falling back to `completed_at`) for time-window boundaries, so cost attribution reflects when work was actually committed rather than when the criterion was marked done
- `tusk criteria reset` clears `committed_at` alongside other completion fields
- `tusk criteria list` displays the `committed_at` column for completed criteria

## Test plan
- [x] Migration 9→10 applies cleanly on existing database
- [x] `committed_at` column exists after migration
- [x] `tusk criteria done` populates `committed_at` with ISO 8601 timestamp
- [x] `tusk criteria list` shows committed_at in output
- [x] All lint conventions pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)