### PR TITLE
[TASK-222] Fix overlapping Status and Criterion headers in dashboard

### DIFF
--- a/bin/tusk-dashboard.py
+++ b/bin/tusk-dashboard.py
@@ -459,7 +459,7 @@ def generate_html(task_metrics: list[dict], complexity_metrics: list[dict] = Non
                 sort_completed = esc(cr.get("completed_at") or "")
                 sort_cost = cr.get("cost_dollars") or 0
                 sort_type = esc(ctype)
-                item_html = f'<div class="criterion-item {css}" data-sort-completed="{sort_completed}" data-sort-cost="{sort_cost}" data-sort-type="{sort_type}"><span class="criterion-id">#{cr["id"]}</span> {check} <span class="criterion-text">{esc(cr["criterion"])}</span>{badges}</div>\n'
+                item_html = f'<div class="criterion-item {css}" data-sort-completed="{sort_completed}" data-sort-cost="{sort_cost}" data-sort-type="{sort_type}"><span class="criterion-id">#{cr["id"]}</span><span class="criterion-status">{check}</span><span class="criterion-text">{esc(cr["criterion"])}</span>{badges}</div>\n'
                 criterion_item_htmls.append((item_html, cr))
 
             # Flat view: all items in original order
@@ -912,7 +912,15 @@ tr.expandable.expanded .expand-icon {{
 }}
 
 .criteria-header-status {{
-  width: 1em;
+  min-width: 3.5em;
+  flex-shrink: 0;
+  white-space: nowrap;
+  text-align: center;
+}}
+
+.criterion-status {{
+  min-width: 3.5em;
+  flex-shrink: 0;
   text-align: center;
 }}
 


### PR DESCRIPTION
## Summary
- Fixed the `.criteria-header-status` CSS from `width: 1em` (too narrow for "Status" text) to `min-width: 3.5em; flex-shrink: 0; white-space: nowrap` so headers no longer overlap
- Wrapped the check mark character in criterion data rows in a `<span class="criterion-status">` with matching `min-width: 3.5em` for column alignment between header and data rows
- Single-file change in `bin/tusk-dashboard.py` — no regressions in other dashboard columns or layout

## Test plan
- [x] Generate dashboard with `tusk dashboard` and verify Status/Criterion headers display cleanly
- [x] Verify proper spacing at typical browser widths (1024px+)
- [x] Confirm no regression in other table columns or criteria detail layout

🤖 Generated with [Claude Code](https://claude.com/claude-code)