### PR TITLE
[TASK-232] Fix summary text ellipsis regression for tasks without dependencies

### DIFF
--- a/bin/tusk-dashboard.py
+++ b/bin/tusk-dashboard.py
@@ -482,10 +482,7 @@ def generate_html(task_metrics: list[dict], complexity_metrics: list[dict] = Non
         priority_score = t.get('priority_score') or 0
         complexity_val = esc(t.get('complexity') or '')
         dep_badges = build_dep_badges(tid)
-        if dep_badges:
-            summary_cell = f'<div class="summary-text">{esc(t["summary"])}</div>{dep_badges}'
-        else:
-            summary_cell = esc(t['summary'])
+        summary_cell = f'<div class="summary-text">{esc(t["summary"])}</div>{dep_badges}'
         task_rows += f"""<tr{cls_attr} data-status="{status_val}" data-summary="{esc(t['summary']).lower()}" data-task-id="{tid}">
   <td class="col-id" data-sort="{tid}">{toggle_icon}#{tid}</td>
   <td class="col-summary">{summary_cell}</td>


### PR DESCRIPTION
## Summary
- Always wrap task summary text in `.summary-text` div regardless of whether dependency badges exist
- Fixes ellipsis truncation regression introduced in TASK-231 where summaries without deps lost `overflow: hidden` / `text-overflow: ellipsis` styling

## Test plan
- [ ] Open dashboard with tasks that have no dependencies — verify long summaries are truncated with ellipsis
- [ ] Open dashboard with tasks that have dependencies — verify dep badges still render correctly alongside summary text

🤖 Generated with [Claude Code](https://claude.com/claude-code)