### PR TITLE
[TASK-240] Add code_reviews and review_comments tables (migration 10→11)

### DIFF
--- a/bin/tusk
+++ b/bin/tusk
@@ -336,6 +336,14 @@ if blocker_types:
 criterion_types = cfg.get('criterion_types', [])
 if criterion_types:
     print(trigger_sql('criterion_type', criterion_types, 'acceptance_criteria'))
+
+review_categories = cfg.get('review_categories', [])
+if review_categories:
+    print(trigger_sql('category', review_categories, 'review_comments'))
+
+review_severities = cfg.get('review_severities', [])
+if review_severities:
+    print(trigger_sql('severity', review_severities, 'review_comments'))
 " "$config"
 }
 
@@ -531,6 +539,45 @@ CREATE TABLE external_blockers (
 CREATE INDEX idx_external_blockers_task_id ON external_blockers(task_id);
 EB_SCHEMA
 
+  # Code reviews and review comments
+  sqlite3 "$DB_PATH" <<'CR_SCHEMA'
+CREATE TABLE code_reviews (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    task_id INTEGER NOT NULL,
+    reviewer TEXT,
+    status TEXT DEFAULT 'pending'
+        CHECK (status IN ('pending', 'in_progress', 'approved', 'changes_requested')),
+    review_pass INTEGER DEFAULT 1,
+    diff_summary TEXT,
+    cost_dollars REAL,
+    tokens_in INTEGER,
+    tokens_out INTEGER,
+    created_at TEXT DEFAULT (datetime('now')),
+    updated_at TEXT DEFAULT (datetime('now')),
+    FOREIGN KEY (task_id) REFERENCES tasks(id) ON DELETE CASCADE
+);
+CREATE INDEX idx_code_reviews_task_id ON code_reviews(task_id);
+
+CREATE TABLE review_comments (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    review_id INTEGER NOT NULL,
+    file_path TEXT,
+    line_start INTEGER,
+    line_end INTEGER,
+    category TEXT,
+    severity TEXT,
+    comment TEXT NOT NULL,
+    resolution TEXT DEFAULT 'pending'
+        CHECK (resolution IN ('pending', 'fixed', 'deferred', 'dismissed')),
+    deferred_task_id INTEGER,
+    created_at TEXT DEFAULT (datetime('now')),
+    updated_at TEXT DEFAULT (datetime('now')),
+    FOREIGN KEY (review_id) REFERENCES code_reviews(id) ON DELETE CASCADE,
+    FOREIGN KEY (deferred_task_id) REFERENCES tasks(id)
+);
+CREATE INDEX idx_review_comments_review_id ON review_comments(review_id);
+CR_SCHEMA
+
   # Apply validation triggers from config (after all tables are created)
   local triggers
   triggers="$(generate_triggers)"
@@ -539,7 +586,7 @@ EB_SCHEMA
   fi
 
   # Set schema version so fresh DBs never need migration
-  sqlite3 "$DB_PATH" "PRAGMA user_version = 10;"
+  sqlite3 "$DB_PATH" "PRAGMA user_version = 11;"
 
   echo "Initialized task database at $DB_PATH"
 }
@@ -846,6 +893,67 @@ cmd_migrate() {
       echo "  Migration 10: added committed_at column to acceptance_criteria"
     else
       sqlite3 "$DB_PATH" "PRAGMA user_version = 10;"
+    fi
+  fi
+
+  # Migration 10→11: add code_reviews and review_comments tables
+  if [[ "$current" -lt 11 ]]; then
+    local has_code_reviews
+    has_code_reviews="$(sqlite3 "$DB_PATH" "SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='code_reviews';")"
+    if [[ "$has_code_reviews" -eq 0 ]]; then
+      sqlite3 "$DB_PATH" "
+        CREATE TABLE code_reviews (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            task_id INTEGER NOT NULL,
+            reviewer TEXT,
+            status TEXT DEFAULT 'pending'
+                CHECK (status IN ('pending', 'in_progress', 'approved', 'changes_requested')),
+            review_pass INTEGER DEFAULT 1,
+            diff_summary TEXT,
+            cost_dollars REAL,
+            tokens_in INTEGER,
+            tokens_out INTEGER,
+            created_at TEXT DEFAULT (datetime('now')),
+            updated_at TEXT DEFAULT (datetime('now')),
+            FOREIGN KEY (task_id) REFERENCES tasks(id) ON DELETE CASCADE
+        );
+        CREATE INDEX idx_code_reviews_task_id ON code_reviews(task_id);
+
+        CREATE TABLE review_comments (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            review_id INTEGER NOT NULL,
+            file_path TEXT,
+            line_start INTEGER,
+            line_end INTEGER,
+            category TEXT,
+            severity TEXT,
+            comment TEXT NOT NULL,
+            resolution TEXT DEFAULT 'pending'
+                CHECK (resolution IN ('pending', 'fixed', 'deferred', 'dismissed')),
+            deferred_task_id INTEGER,
+            created_at TEXT DEFAULT (datetime('now')),
+            updated_at TEXT DEFAULT (datetime('now')),
+            FOREIGN KEY (review_id) REFERENCES code_reviews(id) ON DELETE CASCADE,
+            FOREIGN KEY (deferred_task_id) REFERENCES tasks(id)
+        );
+        CREATE INDEX idx_review_comments_review_id ON review_comments(review_id);
+
+        PRAGMA user_version = 11;
+      "
+
+      # Regenerate triggers to include review_comments category/severity validation
+      local triggers
+      triggers="$(generate_triggers)"
+      if [[ -n "$triggers" ]]; then
+        sqlite3 "$DB_PATH" "
+          $(sqlite3 "$DB_PATH" "SELECT 'DROP TRIGGER IF EXISTS ' || name || ';' FROM sqlite_master WHERE type = 'trigger' AND name LIKE 'validate_%';")
+          $triggers
+        "
+      fi
+
+      echo "  Migration 11: created 'code_reviews' and 'review_comments' tables"
+    else
+      sqlite3 "$DB_PATH" "PRAGMA user_version = 11;"
     fi
   fi
 


### PR DESCRIPTION
## Summary

- Add migration 10→11 creating `code_reviews` table with columns: `task_id` (FK to tasks), `reviewer`, `status` (CHECK: pending/in_progress/approved/changes_requested), `review_pass`, `diff_summary`, and cost tracking (`cost_dollars`, `tokens_in`, `tokens_out`), plus timestamps
- Add `review_comments` table with columns: `review_id` (FK to code_reviews), `file_path`, `line_start`, `line_end`, `category`, `severity`, `comment`, `resolution` (CHECK: pending/fixed/deferred/dismissed), `deferred_task_id` (FK to tasks), plus timestamps
- Update `cmd_init()` fresh-DB schema to include both new tables (schema version bumped from 10→11)
- Add `generate_triggers()` entries for `review_comments.category` (validated against `review_categories` config) and `review_comments.severity` (validated against `review_severities` config)

## Test plan

- [x] `tusk migrate` on a version-10 DB applies migration and creates both tables
- [x] `tusk init --force` creates both tables from scratch at schema version 11
- [x] `code_reviews.status` CHECK constraint rejects invalid values
- [x] `review_comments.resolution` CHECK constraint rejects invalid values
- [x] `generate_triggers()` produces category/severity triggers when config has `review_categories`/`review_severities`
- [x] `tusk lint` passes with no violations

🤖 Generated with [Claude Code](https://claude.com/claude-code)