### PR TITLE
[TASK-242] Create /review-pr skill with orchestrator and reviewer prompt

### DIFF
--- a/skills/review-pr/REVIEWER-PROMPT.md
+++ b/skills/review-pr/REVIEWER-PROMPT.md
@@ -1,0 +1,153 @@
+# Reviewer Agent Prompt Template
+
+Use this template when spawning each background reviewer agent in Step 5 of the `/review-pr` skill. Replace `{placeholders}` with actual values.
+
+---
+
+## Prompt Text
+
+```
+You are a code reviewer agent. Your job is to analyze a PR diff for task #{task_id} and record your findings using the tusk review CLI.
+
+**Review assignment:**
+- Task ID:    {task_id}
+- Review ID:  {review_id}
+- Reviewer:   {reviewer_name}
+
+**Review categories** (use exactly these values when adding comments):
+{review_categories}
+
+**Severity levels** (use exactly these values when adding comments):
+{review_severities}
+
+---
+
+## Category Definitions
+
+**must_fix** — Issues that MUST be addressed before the PR can be merged. Use this for:
+- Logic errors or incorrect behavior
+- Security vulnerabilities (injection, auth bypass, data exposure)
+- Breaking changes to public APIs or CLIs without documentation
+- Crashes, panics, or unhandled error conditions that affect correctness
+- Missing required fields or constraint violations
+- Code that clearly contradicts the task's acceptance criteria
+
+**suggest** — Improvements that are worthwhile but not blocking. Use this for:
+- Code style improvements (naming, readability, organization)
+- Performance optimizations where the current approach is correct but suboptimal
+- Missing but non-critical error handling
+- Test coverage gaps for edge cases (when tests exist but could be more thorough)
+- Minor refactoring opportunities
+
+**defer** — Valid issues that are out of scope for this PR. Use this for:
+- Features or improvements not mentioned in the task description
+- Architectural changes that require broader discussion
+- Known technical debt that should be tracked separately
+- Improvements that depend on other planned tasks
+
+---
+
+## Severity Definitions
+
+**critical** — Causes incorrect behavior, data loss, or security issues in normal usage.
+**major** — Noticeably degrades quality, performance, or reliability; should be fixed soon.
+**minor** — Small improvement; low urgency.
+
+---
+
+## Your Diff to Review
+
+```diff
+{diff_content}
+```
+
+---
+
+## Review Steps
+
+### Step 1: Read and Understand the Diff
+
+Read the entire diff carefully. Understand:
+- What changes were made and why
+- Which files and functions were modified
+- What the task is trying to accomplish (task #{task_id})
+
+### Step 2: Analyze for Issues
+
+Work through each changed file and section of the diff. For each issue you find, determine:
+1. Category: must_fix, suggest, or defer
+2. Severity: critical, major, or minor
+3. File path and line number (approximate is fine)
+4. Clear, actionable description of the issue and how to fix it
+
+Focus your analysis on:
+- **Correctness**: Does the code do what it's supposed to do?
+- **Security**: Are there injection risks, auth gaps, or data exposure issues?
+- **Error handling**: Are errors caught and handled appropriately?
+- **Consistency**: Does the code follow the patterns used elsewhere in the codebase?
+- **Completeness**: Are edge cases handled? Is the implementation complete per the task description?
+- **Style**: Is the code readable and maintainable?
+
+### Step 3: Record Your Findings
+
+For each issue found, add a comment using the tusk CLI:
+
+```bash
+tusk review add-comment {review_id} "<clear description of the issue and how to fix it>" \
+  --file "<file path>" \
+  --line-start <line number> \
+  --category <must_fix|suggest|defer> \
+  --severity <critical|major|minor>
+```
+
+Omit `--file` and `--line-start` for general (non-location-specific) comments.
+
+Example commands:
+```bash
+# A blocking issue in a specific file
+tusk review add-comment {review_id} "SQL query uses string interpolation instead of parameterized query — SQL injection risk" \
+  --file "bin/tusk-example.py" \
+  --line-start 42 \
+  --category must_fix \
+  --severity critical
+
+# A style suggestion
+tusk review add-comment {review_id} "Variable name 'x' is not descriptive — consider renaming to 'task_id'" \
+  --file "bin/tusk-example.py" \
+  --line-start 17 \
+  --category suggest \
+  --severity minor
+
+# An out-of-scope improvement
+tusk review add-comment {review_id} "This function could be extracted to a shared utility module for reuse across scripts" \
+  --category defer \
+  --severity minor
+```
+
+### Step 4: Submit Your Review Verdict
+
+After recording all findings:
+
+- If you found **any must_fix issues**, request changes:
+  ```bash
+  tusk review request-changes {review_id}
+  ```
+
+- If there are **no must_fix issues** (only suggestions or defers, or no issues at all), approve:
+  ```bash
+  tusk review approve {review_id}
+  ```
+
+---
+
+## Guidelines for Good Reviews
+
+- **Be specific and actionable**: Each comment should clearly describe the problem and suggest how to fix it.
+- **Be proportionate**: Reserve `must_fix` for issues that genuinely block the PR. Don't overuse it.
+- **Reference the diff**: Ground each comment in a specific line or section of the diff, not general opinions.
+- **Be concise**: One clear sentence describing the issue is better than a paragraph.
+- **No double-counting**: If you already noted an issue in one comment, don't add a second comment for the same root cause.
+- **Positive notes are unnecessary**: Focus on issues only — the orchestrator doesn't need praise comments.
+
+Complete your review by running either `tusk review approve {review_id}` or `tusk review request-changes {review_id}` — this signals to the orchestrator that you are done.
+```

--- a/skills/review-pr/SKILL.md
+++ b/skills/review-pr/SKILL.md
@@ -1,0 +1,262 @@
+---
+name: review-pr
+description: Run parallel AI code reviewers against a PR diff, fix must_fix issues, and defer or dismiss suggestions
+allowed-tools: Bash, Read, Task
+---
+
+# Review PR Skill
+
+Orchestrates parallel code review against a PR diff. Spawns one background reviewer agent per enabled reviewer in config, monitors completion, fixes must_fix findings, handles suggest findings interactively, and creates deferred tasks for defer findings.
+
+## Arguments
+
+Optional: `/review-pr <task_id>` — if omitted, task ID is inferred from the current branch name.
+
+---
+
+## Step 1: Read Config and Check Mode
+
+```bash
+tusk config
+```
+
+Parse the returned JSON. Extract:
+- `review.mode` — if `"disabled"`, print "Review mode is disabled in config (review.mode = disabled). Enable it in tusk/config.json to use /review-pr." and **stop**.
+- `review.max_passes` — maximum fix-and-re-review cycles (default: 2)
+- `review.reviewers` — list of reviewer names. If empty, a single unassigned review will be used.
+- `review_categories` — valid comment categories (typically `["must_fix", "suggest", "defer"]`)
+- `review_severities` — valid severity levels (typically `["critical", "major", "minor"]`)
+
+## Step 2: Detect Task ID
+
+If a task ID was passed as an argument, use it. Otherwise, infer from the current branch:
+
+```bash
+git branch --show-current
+```
+
+Parse the branch name for the pattern `TASK-<id>` (e.g., `feature/TASK-123-my-feature` → task ID 123). If no task ID can be found, ask the user to provide one.
+
+Verify the task exists:
+
+```bash
+tusk -header -column "SELECT id, summary, status, github_pr FROM tasks WHERE id = <task_id>"
+```
+
+If no row is returned, abort: "Task `<task_id>` not found."
+
+## Step 3: Get the PR Diff
+
+If the task has a `github_pr` URL, use it to fetch the diff:
+
+```bash
+# Extract PR number from URL (e.g., https://github.com/org/repo/pull/42 → 42)
+gh pr diff <pr_number>
+```
+
+If no `github_pr` is set, fall back to comparing against the default branch:
+
+```bash
+git remote set-head origin --auto 2>/dev/null
+DEFAULT_BRANCH=$(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's@^refs/remotes/origin/@@')
+git diff "${DEFAULT_BRANCH}...HEAD"
+```
+
+If the diff is empty, report "No changes found compared to the base branch." and stop.
+
+Capture the diff content — it will be passed to each reviewer agent.
+
+## Step 4: Start Reviews
+
+Start a review record for the task. This creates one `code_reviews` row per configured reviewer (or one unassigned row if no reviewers are configured):
+
+```bash
+tusk review start <task_id> --diff-summary "<first 120 chars of diff or PR title>"
+```
+
+The command prints one line per created review, each showing the review ID. Parse the output to collect all review IDs (e.g., `Started review #<id> for task #<task_id> ...`).
+
+Store the mapping: reviewer name → review_id.
+
+## Step 5: Spawn Parallel Reviewer Agents
+
+Read the reviewer prompt template:
+
+```
+Read file: <base_directory>/REVIEWER-PROMPT.md
+```
+
+Where `<base_directory>` is the skill base directory shown at the top of this file.
+
+For each review_id, spawn a **background agent** using the Task tool. Issue **all Task tool calls in a single message** to run them in parallel:
+
+```
+Task tool call (for EACH review_id):
+  description: "review-pr reviewer <reviewer_name or 'unassigned'> task <task_id>"
+  subagent_type: general-purpose
+  run_in_background: true
+  prompt: <REVIEWER-PROMPT.md content, with placeholders replaced — see template>
+```
+
+Fill in these placeholders from the template:
+- `{task_id}` — the task ID
+- `{review_id}` — the review ID for this reviewer
+- `{reviewer_name}` — the reviewer name, or "unassigned" if none
+- `{diff_content}` — the full diff text
+- `{review_categories}` — comma-separated list from config (e.g., `must_fix, suggest, defer`)
+- `{review_severities}` — comma-separated list from config (e.g., `critical, major, minor`)
+
+After spawning, record a map of: review_id → agent task ID.
+
+## Step 6: Monitor Reviewer Completion
+
+Wait for all reviewer agents to finish:
+
+**Monitoring loop:**
+
+1. Wait 30 seconds:
+   ```bash
+   sleep 30
+   ```
+
+2. Check which reviews are still pending:
+   ```bash
+   tusk review status <task_id>
+   ```
+   Parse the JSON. Reviews with `status = "pending"` are still in progress. If all reviews have `status` of `"approved"` or `"changes_requested"`, exit the loop.
+
+3. For each pending review, check whether its agent has finished using `TaskOutput` with `block: false` and the agent task ID:
+   - If **any agent is still running**, go back to step 1.
+   - If **all agents have completed** but some reviews are still `"pending"`, those agents finished without calling `tusk review approve` or `tusk review request-changes`. Log a warning for each stuck review and continue as if those reviews returned no findings (treat as approved).
+
+## Step 7: Process Findings
+
+After all reviewer agents complete, fetch the full review results for each review:
+
+```bash
+tusk review list <task_id>
+```
+
+Gather all open (unresolved) comments across all reviews. Group them by category:
+
+### must_fix comments
+
+These are blocking issues that must be resolved before the PR can be merged.
+
+For each open `must_fix` comment:
+1. Read the comment details (file path, line numbers, comment text, severity).
+2. Implement the fix directly in the codebase.
+3. After fixing, mark the comment resolved:
+   ```bash
+   tusk review resolve <comment_id> fixed
+   ```
+
+If there are many `must_fix` comments (more than 5), consider spawning a background implementation agent instead:
+
+```
+Task tool call:
+  description: "fix must_fix review comments for task <task_id>"
+  subagent_type: general-purpose
+  run_in_background: false
+  prompt: |
+    Fix the following must_fix code review comments for task <task_id>.
+    After fixing each item, mark it resolved: tusk review resolve <comment_id> fixed
+
+    Findings to fix:
+    <list each comment with file, line, and description>
+
+    Work through them in order. Do not make unrelated changes.
+```
+
+### suggest comments
+
+These are optional improvements. Present each one to the user:
+
+> **Suggestion #<id>** (`<file>:<line>`): <comment text>
+> Fix or dismiss? (f/d)
+
+- **Fix (f)**: implement the suggestion and run `tusk review resolve <comment_id> fixed`
+- **Dismiss (d)**: run `tusk review resolve <comment_id> dismissed`
+
+If there are no interactive users (running in a background agent context), **dismiss all suggest comments** automatically and log them as dismissed.
+
+### defer comments
+
+These are valid issues but out of scope for the current PR. Create a tusk task for each:
+
+```bash
+tusk task-insert "<summary from comment>" "<full comment text>" \
+  --priority Medium \
+  --domain <same domain as current task> \
+  --task-type refactor \
+  --deferred
+```
+
+After creating each deferred task, mark the comment resolved:
+
+```bash
+tusk review resolve <comment_id> deferred
+```
+
+## Step 8: Re-review Loop (if there were must_fix changes)
+
+If any `must_fix` comments were fixed in Step 7, re-run the review to verify the fixes are correct. Cap the number of passes at `max_passes` from config.
+
+Track current pass number (starts at 1). If `current_pass < max_passes`:
+
+1. Get the updated diff:
+   ```bash
+   git diff "${DEFAULT_BRANCH}...HEAD"
+   ```
+   Or re-fetch the PR diff if a PR exists.
+
+2. Start a new review pass:
+   ```bash
+   tusk review start <task_id> --pass-num <current_pass + 1> --diff-summary "Re-review pass <n>"
+   ```
+
+3. Spawn reviewer agents again (Step 5) with the new review IDs and updated diff.
+
+4. Monitor completion (Step 6) and process findings (Step 7).
+
+5. Increment pass counter. If `current_pass >= max_passes` and there are still open `must_fix` items, **escalate to the user**:
+   > Max review passes (<max_passes>) reached. The following must_fix items remain unresolved:
+   > <list each open must_fix comment>
+   >
+   > Please resolve these manually before merging.
+
+   Stop the re-review loop.
+
+If all `must_fix` items are resolved and no new blocking findings were raised, proceed to Step 9.
+
+## Step 9: Final Summary
+
+For each review ID, print the summary:
+
+```bash
+tusk review summary <review_id>
+```
+
+Then print an overall summary:
+
+```
+Review complete for Task <task_id>: <task_summary>
+══════════════════════════════════════════════════
+Reviewers: <count>
+Pass:      <final_pass_number>
+
+must_fix:  <total_count> found, <fixed_count> fixed
+suggest:   <total_count> found, <fixed_count> fixed, <dismissed_count> dismissed
+defer:     <total_count> found, <deferred_count> tasks created
+
+Verdict: APPROVED / CHANGES REMAINING
+```
+
+The verdict is **APPROVED** if all must_fix comments are resolved (fixed). Otherwise, **CHANGES REMAINING**.
+
+If APPROVED, the PR is ready to merge. Suggest:
+
+> All blocking findings have been addressed. The PR is ready to merge:
+> ```bash
+> gh pr merge <pr_number> --squash --delete-branch
+> ```


### PR DESCRIPTION
## Summary

- Adds `skills/review-pr/SKILL.md`: a 9-step orchestration workflow that reads review config, detects the task and PR diff, spawns parallel background reviewer agents (one per configured reviewer), monitors completion, processes findings by category (fix `must_fix`, handle `suggest` interactively, create deferred tasks for `defer`), runs a re-review loop capped at `max_passes`, and prints a final summary with verdict
- Adds `skills/review-pr/REVIEWER-PROMPT.md`: the agent prompt template passed to each spawned reviewer agent, containing category/severity definitions, step-by-step review instructions, and exact `tusk review` CLI commands for adding comments and submitting a verdict
- References `/run-chain` background agent spawning pattern for parallel reviewer agents
- Integrates with `tusk review start/add-comment/approve/request-changes/status/summary` CLI commands from `bin/tusk-review.py`
- Gracefully exits when `review.mode = "disabled"` in config

## Test plan

- [ ] Verify `skills/review-pr/SKILL.md` has valid YAML frontmatter (name, description, allowed-tools)
- [ ] Verify `skills/review-pr/REVIEWER-PROMPT.md` exists and contains all `{placeholder}` variables
- [ ] Verify Step 1 checks `review.mode` and prints a clear message when disabled
- [ ] Verify Step 2 infers task ID from branch name pattern `TASK-<id>`
- [ ] Verify Step 5 spawns one Task tool call per configured reviewer in parallel
- [ ] Verify Step 7 handles all three categories: `must_fix` (fix in code), `suggest` (interactive), `defer` (create task)
- [ ] Verify Step 8 re-review loop respects `max_passes` cap and escalates to user when exceeded
- [ ] Run `tusk sync-skills` and confirm symlink `.claude/skills/review-pr` exists

🤖 Generated with [Claude Code](https://claude.com/claude-code)