### PR TITLE
[TASK-250] Add config.default.json.bak to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ tusk/
 .DS_Store
 __pycache__/
 .claude/skills/
+config.default.json.bak


### PR DESCRIPTION
## Summary

- Adds `config.default.json.bak` to `.gitignore` so it no longer appears as an untracked file in `git status`
- This file is created as a backup by config management flows (e.g., `tusk reconfigure`)

## Test plan

- [ ] Run `git status` — `config.default.json.bak` should not appear as untracked

🤖 Generated with [Claude Code](https://claude.com/claude-code)