### PR TITLE
[TASK-257] Fix branch-naming.sh to skip gracefully in detached HEAD state

### DIFF
--- a/.claude/hooks/branch-naming.sh
+++ b/.claude/hooks/branch-naming.sh
@@ -17,6 +17,11 @@ echo "$command" | grep -qE '(^|[|;&]|&&|\|\||\$\()\s*git\s+push\b' || exit 0
 # Get current branch
 branch=$(git branch --show-current 2>/dev/null)
 
+# Detached HEAD: branch name is empty — not worth policing, allow the push
+if [[ -z "$branch" ]]; then
+  exit 0
+fi
+
 # Allow main, master, and release/* branches without restriction
 if [[ "$branch" == "main" || "$branch" == "master" || "$branch" == release/* ]]; then
   exit 0


### PR DESCRIPTION
## Summary
- Adds an early-exit guard in `.claude/hooks/branch-naming.sh`: when `git branch --show-current` returns an empty string (detached HEAD), the hook now exits 0 immediately instead of falling through to the pattern-mismatch error.

## Test plan
- [ ] Manually verify: `git checkout <commit-sha>` to enter detached HEAD, then attempt `git push` — hook should allow it
- [ ] Normal feature branch pushes still pass
- [ ] Non-matching branch names still get blocked with the expected message

🤖 Generated with [Claude Code](https://claude.com/claude-code)