### PR TITLE
[TASK-262] Add try/finally for DB connection close in tusk-*.py scripts

### DIFF
--- a/bin/tusk-chain.py
+++ b/bin/tusk-chain.py
@@ -235,20 +235,19 @@ Examples:
         sys.exit(1)
 
     conn = get_connection(db_path)
+    try:
+        if not task_exists(conn, args.head_task_id):
+            print(f"Error: Task {args.head_task_id} does not exist", file=sys.stderr)
+            sys.exit(1)
 
-    if not task_exists(conn, args.head_task_id):
-        print(f"Error: Task {args.head_task_id} does not exist", file=sys.stderr)
+        if args.command == "scope":
+            cmd_scope(conn, args.head_task_id)
+        elif args.command == "frontier":
+            cmd_frontier(conn, args.head_task_id)
+        elif args.command == "status":
+            cmd_status(conn, args.head_task_id)
+    finally:
         conn.close()
-        sys.exit(1)
-
-    if args.command == "scope":
-        cmd_scope(conn, args.head_task_id)
-    elif args.command == "frontier":
-        cmd_frontier(conn, args.head_task_id)
-    elif args.command == "status":
-        cmd_status(conn, args.head_task_id)
-
-    conn.close()
 
 
 if __name__ == "__main__":

--- a/bin/tusk-criteria.py
+++ b/bin/tusk-criteria.py
@@ -147,62 +147,60 @@ def get_connection(db_path: str) -> sqlite3.Connection:
 
 def cmd_add(args: argparse.Namespace, db_path: str, config: dict) -> int:
     conn = get_connection(db_path)
+    try:
+        # Verify task exists
+        task = conn.execute("SELECT id FROM tasks WHERE id = ?", (args.task_id,)).fetchone()
+        if not task:
+            print(f"Error: Task {args.task_id} not found", file=sys.stderr)
+            return 2
 
-    # Verify task exists
-    task = conn.execute("SELECT id FROM tasks WHERE id = ?", (args.task_id,)).fetchone()
-    if not task:
-        print(f"Error: Task {args.task_id} not found", file=sys.stderr)
+        # Validate criterion_type against config
+        criterion_types = config.get("criterion_types", [])
+        if criterion_types and args.type not in criterion_types:
+            joined = ", ".join(criterion_types)
+            print(f"Error: Invalid criterion type '{args.type}'. Valid: {joined}", file=sys.stderr)
+            return 2
+
+        # Validate spec: required for non-manual types
+        if args.type in SPEC_REQUIRED_TYPES and not args.spec:
+            print(f"Error: --spec is required for criterion type '{args.type}'", file=sys.stderr)
+            return 2
+
+        conn.execute(
+            "INSERT INTO acceptance_criteria (task_id, criterion, source, criterion_type, verification_spec) "
+            "VALUES (?, ?, ?, ?, ?)",
+            (args.task_id, args.text, args.source, args.type, args.spec),
+        )
+        conn.commit()
+
+        cid = conn.execute("SELECT last_insert_rowid()").fetchone()[0]
+        type_suffix = f" (type: {args.type})" if args.type != "manual" else ""
+        print(f"Added criterion #{cid} to task #{args.task_id}{type_suffix}")
+        return 0
+    finally:
         conn.close()
-        return 2
-
-    # Validate criterion_type against config
-    criterion_types = config.get("criterion_types", [])
-    if criterion_types and args.type not in criterion_types:
-        joined = ", ".join(criterion_types)
-        print(f"Error: Invalid criterion type '{args.type}'. Valid: {joined}", file=sys.stderr)
-        conn.close()
-        return 2
-
-    # Validate spec: required for non-manual types
-    if args.type in SPEC_REQUIRED_TYPES and not args.spec:
-        print(f"Error: --spec is required for criterion type '{args.type}'", file=sys.stderr)
-        conn.close()
-        return 2
-
-    conn.execute(
-        "INSERT INTO acceptance_criteria (task_id, criterion, source, criterion_type, verification_spec) "
-        "VALUES (?, ?, ?, ?, ?)",
-        (args.task_id, args.text, args.source, args.type, args.spec),
-    )
-    conn.commit()
-
-    cid = conn.execute("SELECT last_insert_rowid()").fetchone()[0]
-    conn.close()
-    type_suffix = f" (type: {args.type})" if args.type != "manual" else ""
-    print(f"Added criterion #{cid} to task #{args.task_id}{type_suffix}")
-    return 0
 
 
 def cmd_list(args: argparse.Namespace, db_path: str, config: dict) -> int:
     conn = get_connection(db_path)
+    try:
+        # Verify task exists
+        task = conn.execute(
+            "SELECT id, summary FROM tasks WHERE id = ?", (args.task_id,)
+        ).fetchone()
+        if not task:
+            print(f"Error: Task {args.task_id} not found", file=sys.stderr)
+            return 2
 
-    # Verify task exists
-    task = conn.execute(
-        "SELECT id, summary FROM tasks WHERE id = ?", (args.task_id,)
-    ).fetchone()
-    if not task:
-        print(f"Error: Task {args.task_id} not found", file=sys.stderr)
+        rows = conn.execute(
+            "SELECT id, criterion, source, is_completed, is_deferred, deferred_reason, "
+            "cost_dollars, tokens_in, tokens_out, "
+            "criterion_type, verification_spec, commit_hash, committed_at, created_at "
+            "FROM acceptance_criteria WHERE task_id = ? ORDER BY id",
+            (args.task_id,),
+        ).fetchall()
+    finally:
         conn.close()
-        return 2
-
-    rows = conn.execute(
-        "SELECT id, criterion, source, is_completed, is_deferred, deferred_reason, "
-        "cost_dollars, tokens_in, tokens_out, "
-        "criterion_type, verification_spec, commit_hash, committed_at, created_at "
-        "FROM acceptance_criteria WHERE task_id = ? ORDER BY id",
-        (args.task_id,),
-    ).fetchall()
-    conn.close()
 
     if not rows:
         print(f"No acceptance criteria for task #{args.task_id}: {task['summary']}")
@@ -245,170 +243,165 @@ def cmd_list(args: argparse.Namespace, db_path: str, config: dict) -> int:
 
 def cmd_done(args: argparse.Namespace, db_path: str, config: dict) -> int:
     conn = get_connection(db_path)
-
-    row = conn.execute(
-        "SELECT id, task_id, criterion, is_completed, criterion_type, verification_spec "
-        "FROM acceptance_criteria WHERE id = ?",
-        (args.criterion_id,),
-    ).fetchone()
-    if not row:
-        print(f"Error: Criterion {args.criterion_id} not found", file=sys.stderr)
-        conn.close()
-        return 2
-
-    if row["is_completed"]:
-        print(f"Criterion #{args.criterion_id} is already completed")
-        conn.close()
-        return 0
-
-    criterion_type = row["criterion_type"] or "manual"
-    spec = row["verification_spec"]
-
-    # Run verification for non-manual types (unless --skip-verify)
-    verification_result = None
-    if criterion_type != "manual" and spec and not args.skip_verify:
-        result = run_verification(criterion_type, spec)
-        verification_result = json.dumps(result)
-
-        if not result["passed"]:
-            # Store the failed result
-            conn.execute(
-                "UPDATE acceptance_criteria SET verification_result = ?, "
-                "updated_at = datetime('now') WHERE id = ?",
-                (verification_result, args.criterion_id),
-            )
-            conn.commit()
-            conn.close()
-
-            print(f"Verification FAILED for criterion #{args.criterion_id} ({criterion_type}):",
-                  file=sys.stderr)
-            if result["output"]:
-                print(result["output"], file=sys.stderr)
-            print("Use --skip-verify to bypass verification.", file=sys.stderr)
-            return 1
-
-    # Best-effort: capture current git HEAD short hash and commit timestamp
-    commit_hash = None
-    committed_at = None
     try:
-        commit_hash = subprocess.check_output(
-            ["git", "rev-parse", "--short", "HEAD"],
-            stderr=subprocess.DEVNULL,
-        ).decode().strip() or None
-        if commit_hash:
-            committed_at = subprocess.check_output(
-                ["git", "log", "-1", "--format=%cI", "HEAD"],
+        row = conn.execute(
+            "SELECT id, task_id, criterion, is_completed, criterion_type, verification_spec "
+            "FROM acceptance_criteria WHERE id = ?",
+            (args.criterion_id,),
+        ).fetchone()
+        if not row:
+            print(f"Error: Criterion {args.criterion_id} not found", file=sys.stderr)
+            return 2
+
+        if row["is_completed"]:
+            print(f"Criterion #{args.criterion_id} is already completed")
+            return 0
+
+        criterion_type = row["criterion_type"] or "manual"
+        spec = row["verification_spec"]
+
+        # Run verification for non-manual types (unless --skip-verify)
+        verification_result = None
+        if criterion_type != "manual" and spec and not args.skip_verify:
+            result = run_verification(criterion_type, spec)
+            verification_result = json.dumps(result)
+
+            if not result["passed"]:
+                # Store the failed result
+                conn.execute(
+                    "UPDATE acceptance_criteria SET verification_result = ?, "
+                    "updated_at = datetime('now') WHERE id = ?",
+                    (verification_result, args.criterion_id),
+                )
+                conn.commit()
+
+                print(f"Verification FAILED for criterion #{args.criterion_id} ({criterion_type}):",
+                      file=sys.stderr)
+                if result["output"]:
+                    print(result["output"], file=sys.stderr)
+                print("Use --skip-verify to bypass verification.", file=sys.stderr)
+                return 1
+
+        # Best-effort: capture current git HEAD short hash and commit timestamp
+        commit_hash = None
+        committed_at = None
+        try:
+            commit_hash = subprocess.check_output(
+                ["git", "rev-parse", "--short", "HEAD"],
                 stderr=subprocess.DEVNULL,
             ).decode().strip() or None
-    except Exception:
-        pass  # Non-git environment — leave as NULL
+            if commit_hash:
+                committed_at = subprocess.check_output(
+                    ["git", "log", "-1", "--format=%cI", "HEAD"],
+                    stderr=subprocess.DEVNULL,
+                ).decode().strip() or None
+        except Exception:
+            pass  # Non-git environment — leave as NULL
 
-    # Warn if another completed criterion on this task already has this commit hash
-    if commit_hash is not None:
-        dup = conn.execute(
-            "SELECT id FROM acceptance_criteria "
-            "WHERE task_id = ? AND id <> ? AND commit_hash = ? AND is_completed = 1 "
-            "LIMIT 1",
-            (row["task_id"], args.criterion_id, commit_hash),
-        ).fetchone()
-        if dup:
-            print(
-                f"Warning: Criterion #{args.criterion_id} shares commit {commit_hash} "
-                f"with criterion #{dup['id']}.\n"
-                f"Commit separately per criterion for accurate cost attribution.",
-                file=sys.stderr,
-            )
+        # Warn if another completed criterion on this task already has this commit hash
+        if commit_hash is not None:
+            dup = conn.execute(
+                "SELECT id FROM acceptance_criteria "
+                "WHERE task_id = ? AND id <> ? AND commit_hash = ? AND is_completed = 1 "
+                "LIMIT 1",
+                (row["task_id"], args.criterion_id, commit_hash),
+            ).fetchone()
+            if dup:
+                print(
+                    f"Warning: Criterion #{args.criterion_id} shares commit {commit_hash} "
+                    f"with criterion #{dup['id']}.\n"
+                    f"Commit separately per criterion for accurate cost attribution.",
+                    file=sys.stderr,
+                )
 
-    conn.execute(
-        "UPDATE acceptance_criteria SET is_completed = 1, "
-        "completed_at = strftime('%Y-%m-%d %H:%M:%f', 'now'), "
-        "commit_hash = ?, committed_at = ?, "
-        "verification_result = ?, updated_at = datetime('now') WHERE id = ?",
-        (commit_hash, committed_at, verification_result, args.criterion_id),
-    )
-    conn.commit()
+        conn.execute(
+            "UPDATE acceptance_criteria SET is_completed = 1, "
+            "completed_at = strftime('%Y-%m-%d %H:%M:%f', 'now'), "
+            "commit_hash = ?, committed_at = ?, "
+            "verification_result = ?, updated_at = datetime('now') WHERE id = ?",
+            (commit_hash, committed_at, verification_result, args.criterion_id),
+        )
+        conn.commit()
 
-    # Best-effort cost capture
-    capture_criterion_cost(conn, args.criterion_id, row["task_id"])
-    conn.commit()
+        # Best-effort cost capture
+        capture_criterion_cost(conn, args.criterion_id, row["task_id"])
+        conn.commit()
 
-    conn.close()
-    verified_msg = ""
-    if criterion_type != "manual" and not args.skip_verify:
-        verified_msg = " (verification passed)"
-    elif criterion_type != "manual" and args.skip_verify:
-        verified_msg = " (verification skipped)"
-    print(f"Criterion #{args.criterion_id} marked done{verified_msg}: {row['criterion']}")
-    return 0
+        verified_msg = ""
+        if criterion_type != "manual" and not args.skip_verify:
+            verified_msg = " (verification passed)"
+        elif criterion_type != "manual" and args.skip_verify:
+            verified_msg = " (verification skipped)"
+        print(f"Criterion #{args.criterion_id} marked done{verified_msg}: {row['criterion']}")
+        return 0
+    finally:
+        conn.close()
 
 
 def cmd_skip(args: argparse.Namespace, db_path: str, config: dict) -> int:
     conn = get_connection(db_path)
+    try:
+        row = conn.execute(
+            "SELECT id, task_id, criterion, is_completed, is_deferred, deferred_reason "
+            "FROM acceptance_criteria WHERE id = ?",
+            (args.criterion_id,),
+        ).fetchone()
+        if not row:
+            print(f"Error: Criterion {args.criterion_id} not found", file=sys.stderr)
+            return 2
 
-    row = conn.execute(
-        "SELECT id, task_id, criterion, is_completed, is_deferred, deferred_reason "
-        "FROM acceptance_criteria WHERE id = ?",
-        (args.criterion_id,),
-    ).fetchone()
-    if not row:
-        print(f"Error: Criterion {args.criterion_id} not found", file=sys.stderr)
-        conn.close()
-        return 2
+        if row["is_completed"]:
+            print(f"Criterion #{args.criterion_id} is already completed")
+            return 0
 
-    if row["is_completed"]:
-        print(f"Criterion #{args.criterion_id} is already completed")
-        conn.close()
-        return 0
+        if row["is_deferred"]:
+            print(
+                f"Criterion #{args.criterion_id} is already deferred "
+                f"(reason: {row['deferred_reason']}): {row['criterion']}"
+            )
+            return 0
 
-    if row["is_deferred"]:
-        print(
-            f"Criterion #{args.criterion_id} is already deferred "
-            f"(reason: {row['deferred_reason']}): {row['criterion']}"
+        conn.execute(
+            "UPDATE acceptance_criteria SET is_deferred = 1, deferred_reason = ?, "
+            "updated_at = datetime('now') WHERE id = ?",
+            (args.reason, args.criterion_id),
         )
-        conn.close()
+        conn.commit()
+        print(f"Criterion #{args.criterion_id} marked as deferred (reason: {args.reason}): {row['criterion']}")
         return 0
-
-    conn.execute(
-        "UPDATE acceptance_criteria SET is_deferred = 1, deferred_reason = ?, "
-        "updated_at = datetime('now') WHERE id = ?",
-        (args.reason, args.criterion_id),
-    )
-    conn.commit()
-    conn.close()
-    print(f"Criterion #{args.criterion_id} marked as deferred (reason: {args.reason}): {row['criterion']}")
-    return 0
+    finally:
+        conn.close()
 
 
 def cmd_reset(args: argparse.Namespace, db_path: str, config: dict) -> int:
     conn = get_connection(db_path)
+    try:
+        row = conn.execute(
+            "SELECT id, task_id, criterion, is_completed, is_deferred "
+            "FROM acceptance_criteria WHERE id = ?",
+            (args.criterion_id,),
+        ).fetchone()
+        if not row:
+            print(f"Error: Criterion {args.criterion_id} not found", file=sys.stderr)
+            return 2
 
-    row = conn.execute(
-        "SELECT id, task_id, criterion, is_completed, is_deferred "
-        "FROM acceptance_criteria WHERE id = ?",
-        (args.criterion_id,),
-    ).fetchone()
-    if not row:
-        print(f"Error: Criterion {args.criterion_id} not found", file=sys.stderr)
-        conn.close()
-        return 2
+        if not row["is_completed"] and not row["is_deferred"]:
+            print(f"Criterion #{args.criterion_id} is already incomplete and not deferred")
+            return 0
 
-    if not row["is_completed"] and not row["is_deferred"]:
-        print(f"Criterion #{args.criterion_id} is already incomplete and not deferred")
-        conn.close()
+        conn.execute(
+            "UPDATE acceptance_criteria SET is_completed = 0, completed_at = NULL, "
+            "cost_dollars = NULL, tokens_in = NULL, tokens_out = NULL, "
+            "verification_result = NULL, commit_hash = NULL, committed_at = NULL, "
+            "is_deferred = 0, deferred_reason = NULL, "
+            "updated_at = datetime('now') WHERE id = ?",
+            (args.criterion_id,),
+        )
+        conn.commit()
+        print(f"Criterion #{args.criterion_id} reset to incomplete: {row['criterion']}")
         return 0
-
-    conn.execute(
-        "UPDATE acceptance_criteria SET is_completed = 0, completed_at = NULL, "
-        "cost_dollars = NULL, tokens_in = NULL, tokens_out = NULL, "
-        "verification_result = NULL, commit_hash = NULL, committed_at = NULL, "
-        "is_deferred = 0, deferred_reason = NULL, "
-        "updated_at = datetime('now') WHERE id = ?",
-        (args.criterion_id,),
-    )
-    conn.commit()
-    conn.close()
-    print(f"Criterion #{args.criterion_id} reset to incomplete: {row['criterion']}")
-    return 0
+    finally:
+        conn.close()
 
 
 # ── CLI ──────────────────────────────────────────────────────────────

--- a/bin/tusk-dashboard.py
+++ b/bin/tusk-dashboard.py
@@ -3725,20 +3725,22 @@ def main():
 
     # Fetch data
     conn = get_connection(db_path)
-    task_metrics = fetch_task_metrics(conn)
-    kpi_data = fetch_kpi_data(conn)
-    cost_by_domain = fetch_cost_by_domain(conn)
-    complexity_metrics = fetch_complexity_metrics(conn)
-    cost_trend = fetch_cost_trend(conn)
-    cost_trend_daily = fetch_cost_trend_daily(conn)
-    cost_trend_monthly = fetch_cost_trend_monthly(conn)
-    all_criteria = fetch_all_criteria(conn)
-    task_deps = fetch_task_dependencies(conn)
-    # DAG data
-    dag_tasks = fetch_dag_tasks(conn)
-    dag_edges = fetch_edges(conn)
-    dag_blockers = fetch_blockers(conn)
-    conn.close()
+    try:
+        task_metrics = fetch_task_metrics(conn)
+        kpi_data = fetch_kpi_data(conn)
+        cost_by_domain = fetch_cost_by_domain(conn)
+        complexity_metrics = fetch_complexity_metrics(conn)
+        cost_trend = fetch_cost_trend(conn)
+        cost_trend_daily = fetch_cost_trend_daily(conn)
+        cost_trend_monthly = fetch_cost_trend_monthly(conn)
+        all_criteria = fetch_all_criteria(conn)
+        task_deps = fetch_task_dependencies(conn)
+        # DAG data
+        dag_tasks = fetch_dag_tasks(conn)
+        dag_edges = fetch_edges(conn)
+        dag_blockers = fetch_blockers(conn)
+    finally:
+        conn.close()
 
     log.debug("Cost by domain: %s", cost_by_domain)
 

--- a/bin/tusk-deps.py
+++ b/bin/tusk-deps.py
@@ -353,23 +353,23 @@ Examples:
         sys.exit(1)
 
     conn = get_connection(db_path)
-
-    if args.command == "add":
-        add_dependency(conn, args.task_id, args.depends_on_id, args.relationship_type)
-    elif args.command == "remove":
-        remove_dependency(conn, args.task_id, args.depends_on_id)
-    elif args.command == "list":
-        list_dependencies(conn, args.task_id)
-    elif args.command == "dependents":
-        list_dependents(conn, args.task_id)
-    elif args.command == "blocked":
-        show_blocked(conn)
-    elif args.command == "ready":
-        show_ready(conn)
-    elif args.command == "all":
-        show_all(conn)
-
-    conn.close()
+    try:
+        if args.command == "add":
+            add_dependency(conn, args.task_id, args.depends_on_id, args.relationship_type)
+        elif args.command == "remove":
+            remove_dependency(conn, args.task_id, args.depends_on_id)
+        elif args.command == "list":
+            list_dependencies(conn, args.task_id)
+        elif args.command == "dependents":
+            list_dependents(conn, args.task_id)
+        elif args.command == "blocked":
+            show_blocked(conn)
+        elif args.command == "ready":
+            show_ready(conn)
+        elif args.command == "all":
+            show_all(conn)
+    finally:
+        conn.close()
 
 
 if __name__ == "__main__":

--- a/bin/tusk-setup.py
+++ b/bin/tusk-setup.py
@@ -39,12 +39,14 @@ def main(argv: list[str]) -> int:
         conn = sqlite3.connect(db_path)
         conn.row_factory = sqlite3.Row
         conn.execute("PRAGMA foreign_keys = ON")
-        rows = conn.execute(
-            "SELECT id, summary, status, priority, domain, assignee, complexity, task_type, priority_score "
-            "FROM tasks WHERE status <> 'Done' ORDER BY priority_score DESC, id"
-        ).fetchall()
-        backlog = [dict(row) for row in rows]
-        conn.close()
+        try:
+            rows = conn.execute(
+                "SELECT id, summary, status, priority, domain, assignee, complexity, task_type, priority_score "
+                "FROM tasks WHERE status <> 'Done' ORDER BY priority_score DESC, id"
+            ).fetchall()
+            backlog = [dict(row) for row in rows]
+        finally:
+            conn.close()
     except sqlite3.Error as e:
         print(f"Error: Database query failed: {e}", file=sys.stderr)
         return 2

--- a/bin/tusk-task-done.py
+++ b/bin/tusk-task-done.py
@@ -80,88 +80,86 @@ def main(argv: list[str]) -> int:
         return 1
 
     conn = get_connection(db_path)
+    try:
+        # 1. Fetch and validate the task
+        task = conn.execute("SELECT * FROM tasks WHERE id = ?", (task_id,)).fetchone()
+        if not task:
+            print(f"Error: Task {task_id} not found", file=sys.stderr)
+            return 2
 
-    # 1. Fetch and validate the task
-    task = conn.execute("SELECT * FROM tasks WHERE id = ?", (task_id,)).fetchone()
-    if not task:
-        print(f"Error: Task {task_id} not found", file=sys.stderr)
+        if task["status"] == "Done":
+            print(f"Error: Task {task_id} is already Done", file=sys.stderr)
+            return 2
+
+        # 2. Check for uncompleted acceptance criteria (deferred criteria do not block closure)
+        open_criteria = conn.execute(
+            "SELECT id, criterion FROM acceptance_criteria "
+            "WHERE task_id = ? AND is_completed = 0 AND is_deferred = 0",
+            (task_id,),
+        ).fetchall()
+
+        if open_criteria and not force:
+            print(f"Error: Task {task_id} has {len(open_criteria)} uncompleted acceptance criteria:", file=sys.stderr)
+            for row in open_criteria:
+                print(f"  [{row['id']}] {row['criterion']}", file=sys.stderr)
+            print("\nUse --force to close anyway.", file=sys.stderr)
+            return 3
+
+        # 3. Close all open sessions
+        cursor = conn.execute(
+            "UPDATE task_sessions "
+            "SET ended_at = datetime('now'), "
+            "    duration_seconds = CAST((julianday(datetime('now')) - julianday(started_at)) * 86400 AS INTEGER), "
+            "    lines_added = COALESCE(lines_added, 0), "
+            "    lines_removed = COALESCE(lines_removed, 0) "
+            "WHERE task_id = ? AND ended_at IS NULL",
+            (task_id,),
+        )
+        sessions_closed = cursor.rowcount
+
+        # 4. Update task status to Done
+        conn.execute(
+            "UPDATE tasks SET status = 'Done', closed_reason = ?, updated_at = datetime('now') WHERE id = ?",
+            (reason, task_id),
+        )
+
+        conn.commit()
+
+        # 5. Find newly unblocked tasks
+        unblocked_rows = conn.execute(
+            "SELECT t.id, t.summary, t.priority, t.priority_score "
+            "FROM tasks t "
+            "JOIN task_dependencies d ON t.id = d.task_id "
+            "WHERE d.depends_on_id = ? "
+            "  AND t.status = 'To Do' "
+            "  AND NOT EXISTS ( "
+            "    SELECT 1 FROM task_dependencies d2 "
+            "    JOIN tasks blocker ON d2.depends_on_id = blocker.id "
+            "    WHERE d2.task_id = t.id AND blocker.status <> 'Done' "
+            "  ) "
+            "  AND NOT EXISTS ( "
+            "    SELECT 1 FROM external_blockers eb "
+            "    WHERE eb.task_id = t.id AND eb.is_resolved = 0 "
+            "  )",
+            (task_id,),
+        ).fetchall()
+
+        # 6. Build and return JSON result
+        # Re-fetch task to get updated values
+        updated_task = conn.execute("SELECT * FROM tasks WHERE id = ?", (task_id,)).fetchone()
+        task_dict = {key: updated_task[key] for key in updated_task.keys()}
+        unblocked_list = [{key: row[key] for key in row.keys()} for row in unblocked_rows]
+
+        result = {
+            "task": task_dict,
+            "sessions_closed": sessions_closed,
+            "unblocked_tasks": unblocked_list,
+        }
+
+        print(json.dumps(result, indent=2))
+        return 0
+    finally:
         conn.close()
-        return 2
-
-    if task["status"] == "Done":
-        print(f"Error: Task {task_id} is already Done", file=sys.stderr)
-        conn.close()
-        return 2
-
-    # 2. Check for uncompleted acceptance criteria (deferred criteria do not block closure)
-    open_criteria = conn.execute(
-        "SELECT id, criterion FROM acceptance_criteria "
-        "WHERE task_id = ? AND is_completed = 0 AND is_deferred = 0",
-        (task_id,),
-    ).fetchall()
-
-    if open_criteria and not force:
-        print(f"Error: Task {task_id} has {len(open_criteria)} uncompleted acceptance criteria:", file=sys.stderr)
-        for row in open_criteria:
-            print(f"  [{row['id']}] {row['criterion']}", file=sys.stderr)
-        print("\nUse --force to close anyway.", file=sys.stderr)
-        conn.close()
-        return 3
-
-    # 3. Close all open sessions
-    cursor = conn.execute(
-        "UPDATE task_sessions "
-        "SET ended_at = datetime('now'), "
-        "    duration_seconds = CAST((julianday(datetime('now')) - julianday(started_at)) * 86400 AS INTEGER), "
-        "    lines_added = COALESCE(lines_added, 0), "
-        "    lines_removed = COALESCE(lines_removed, 0) "
-        "WHERE task_id = ? AND ended_at IS NULL",
-        (task_id,),
-    )
-    sessions_closed = cursor.rowcount
-
-    # 4. Update task status to Done
-    conn.execute(
-        "UPDATE tasks SET status = 'Done', closed_reason = ?, updated_at = datetime('now') WHERE id = ?",
-        (reason, task_id),
-    )
-
-    conn.commit()
-
-    # 5. Find newly unblocked tasks
-    unblocked_rows = conn.execute(
-        "SELECT t.id, t.summary, t.priority, t.priority_score "
-        "FROM tasks t "
-        "JOIN task_dependencies d ON t.id = d.task_id "
-        "WHERE d.depends_on_id = ? "
-        "  AND t.status = 'To Do' "
-        "  AND NOT EXISTS ( "
-        "    SELECT 1 FROM task_dependencies d2 "
-        "    JOIN tasks blocker ON d2.depends_on_id = blocker.id "
-        "    WHERE d2.task_id = t.id AND blocker.status <> 'Done' "
-        "  ) "
-        "  AND NOT EXISTS ( "
-        "    SELECT 1 FROM external_blockers eb "
-        "    WHERE eb.task_id = t.id AND eb.is_resolved = 0 "
-        "  )",
-        (task_id,),
-    ).fetchall()
-
-    # 6. Build and return JSON result
-    # Re-fetch task to get updated values
-    updated_task = conn.execute("SELECT * FROM tasks WHERE id = ?", (task_id,)).fetchone()
-    task_dict = {key: updated_task[key] for key in updated_task.keys()}
-    unblocked_list = [{key: row[key] for key in row.keys()} for row in unblocked_rows]
-
-    result = {
-        "task": task_dict,
-        "sessions_closed": sessions_closed,
-        "unblocked_tasks": unblocked_list,
-    }
-
-    print(json.dumps(result, indent=2))
-    conn.close()
-    return 0
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- Audited all 17 `tusk-*.py` scripts that open SQLite connections
- Wrapped every `conn = get_connection(db_path)` call in a `try/finally: conn.close()` block to guarantee the connection is closed even if an unhandled exception occurs
- Removed all scattered intermediate `conn.close()` calls in early-return branches (now handled by `finally`)
- `tusk-loop.py` (fixed in TASK-261) and `tusk-task-insert.py` (already used try/finally) required no changes
- `tusk-finalize.py` has no direct SQLite connections (delegates via subprocess) — no changes needed
- Bonus fix in `tusk-review.py cmd_list`: eliminated the redundant per-review re-open of `conn2` by fetching all comments in a single query before closing the connection

## Scripts fixed (15 files)

`tusk-task-start.py`, `tusk-task-done.py`, `tusk-task-update.py`, `tusk-autoclose.py`, `tusk-chain.py`, `tusk-deps.py`, `tusk-dashboard.py`, `tusk-progress.py`, `tusk-session-recalc.py`, `tusk-session-stats.py`, `tusk-setup.py`, `tusk-blockers.py`, `tusk-dupes.py`, `tusk-criteria.py`, `tusk-review.py`

## Test plan

- [ ] `tusk task-start <id>` — starts task, returns JSON
- [ ] `tusk task-done <id> --reason completed` — closes task
- [ ] `tusk criteria list <id>` — lists criteria
- [ ] `tusk blockers list <id>` — lists blockers
- [ ] `tusk deps ready` — shows ready tasks
- [ ] `tusk autoclose` — runs without error
- [ ] Lint passes: `tusk lint`

🤖 Generated with [Claude Code](https://claude.com/claude-code)