### PR TITLE
[TASK-263] Move print summary block inside try block in tusk-session-stats.py

### DIFF
--- a/bin/tusk-session-stats.py
+++ b/bin/tusk-session-stats.py
@@ -130,19 +130,19 @@ def main():
             (tokens_in, tokens_out, cost, model, session_id),
         )
         conn.commit()
+
+        # Print summary
+        print(f"Session {session_id} token stats updated:")
+        print(f"  Model:        {model}")
+        print(f"  Requests:     {totals['request_count']}")
+        print(f"  Input tokens: {tokens_in:,} (base: {totals['input_tokens']:,}, "
+              f"cache write 5m: {totals['cache_creation_5m_tokens']:,}, "
+              f"cache write 1h: {totals['cache_creation_1h_tokens']:,}, "
+              f"cache read: {totals['cache_read_input_tokens']:,})")
+        print(f"  Output tokens: {tokens_out:,}")
+        print(f"  Est. cost:    ${cost:.4f}")
     finally:
         conn.close()
-
-    # Print summary
-    print(f"Session {session_id} token stats updated:")
-    print(f"  Model:        {model}")
-    print(f"  Requests:     {totals['request_count']}")
-    print(f"  Input tokens: {tokens_in:,} (base: {totals['input_tokens']:,}, "
-          f"cache write 5m: {totals['cache_creation_5m_tokens']:,}, "
-          f"cache write 1h: {totals['cache_creation_1h_tokens']:,}, "
-          f"cache read: {totals['cache_read_input_tokens']:,})")
-    print(f"  Output tokens: {tokens_out:,}")
-    print(f"  Est. cost:    ${cost:.4f}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- Moves the print summary block (lines that print session token stats) inside the `try` block in `main()` of `tusk-session-stats.py`
- Previously, the block appeared after the `try/finally`, referencing variables (`model`, `tokens_in`, `tokens_out`, `totals`, `cost`) that are only assigned inside the `try`
- Currently safe because all non-success paths call `sys.exit()`, but fragile: any future return path added inside the `try` block could cause a `NameError`
- Discovered during TASK-262 PR review (review comment #10)

## Test plan

- [ ] Run `tusk session-stats` against a real session and verify output is unchanged
- [ ] Confirm the print block is now inside the `try` block (before `finally: conn.close()`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)