### PR TITLE
[TASK-273] Update automated dispatch skills to use tusk task-start --force

### DIFF
--- a/skills/chain/SKILL.md
+++ b/skills/chain/SKILL.md
@@ -295,9 +295,9 @@ Complexity: {complexity}
 
 1. **Start the task:**
    ```
-   tusk task-start {id}
+   tusk task-start {id} --force
    ```
-   This returns JSON with task details, prior progress, criteria, and a session_id. Hold onto the session_id. The `criteria` array contains acceptance criteria — work through them in order and mark each done as you complete it.
+   The `--force` flag ensures the workflow proceeds even if the task has no acceptance criteria (emits a warning rather than hard-failing). This returns JSON with task details, prior progress, criteria, and a session_id. Hold onto the session_id. The `criteria` array contains acceptance criteria — work through them in order and mark each done as you complete it.
 
 2. **Create a git branch** from the default branch:
    ```

--- a/skills/loop/SKILL.md
+++ b/skills/loop/SKILL.md
@@ -30,6 +30,8 @@ tusk loop --dry-run
    - **Standalone** → `claude -p /next-task <id>`
 4. Stops on non-zero exit from any agent, on empty backlog, or when `--max-tasks` is reached
 
+> **Note:** Tasks dispatched via `/next-task` or `/chain` use `tusk task-start --force` so that zero-criteria tasks emit a warning rather than hard-failing the automated workflow.
+
 ## Flags
 
 | Flag | Description |

--- a/skills/next-task/SKILL.md
+++ b/skills/next-task/SKILL.md
@@ -77,9 +77,9 @@ When called with a task ID (e.g., `/next-task 6`), begin the full development wo
 
 1. **Start the task** — fetch details, check progress, create/reuse session, and set status in one call:
    ```bash
-   tusk task-start <id>
+   tusk task-start <id> --force
    ```
-   This returns a JSON blob with four keys:
+   The `--force` flag ensures the workflow proceeds even if the task has no acceptance criteria (emits a warning rather than hard-failing). This returns a JSON blob with four keys:
    - `task` — full task row (summary, description, priority, domain, assignee, etc.)
    - `progress` — array of prior progress checkpoints (most recent first). If non-empty, the first entry's `next_steps` tells you exactly where to pick up. Skip steps you've already completed (branch may already exist, some commits may already be made). Use `git log --oneline` on the existing branch to see what's already been done.
    - `criteria` — array of acceptance criteria objects (id, criterion, source, is_completed, criterion_type, verification_spec). These are the implementation checklist. Work through them in order during implementation. Mark each criterion done (`tusk criteria done <cid>`) as you complete it — do not defer this to the end. Non-manual criteria (type: code, test, file) run automated verification on `done`; use `--skip-verify` if needed. If the array is empty, proceed normally using the description as scope.

--- a/skills/resume-task/SKILL.md
+++ b/skills/resume-task/SKILL.md
@@ -24,8 +24,10 @@ echo "Task ID: $TASK_ID"
 ## Step 2: Start the Task (Idempotent)
 
 ```bash
-tusk task-start <TASK_ID>
+tusk task-start <TASK_ID> --force
 ```
+
+The `--force` flag ensures the workflow proceeds even if the task has no acceptance criteria (emits a warning rather than hard-failing).
 
 Returns JSON with four keys:
 


### PR DESCRIPTION
## Summary

- Updates `/next-task`, `/chain`, `/loop`, and `/resume-task` skills to use `tusk task-start <id> --force` instead of `tusk task-start <id>`
- Prevents hard-failure when an automated workflow encounters a task with zero acceptance criteria — now emits a warning and continues instead

## Why

`tusk task-start` exits 2 for tasks with no acceptance criteria (added in TASK-271). Automated dispatch paths (`/next-task`, `/loop`, `/chain`, `/resume-task`) should not hard-fail on misconfigured tasks; `--force` makes them warn and proceed gracefully.

## Test plan
- [ ] Verify `/next-task` step 1 shows `tusk task-start <id> --force`
- [ ] Verify `/loop` SKILL.md includes a note about `--force`
- [ ] Verify `/chain` agent prompt template uses `tusk task-start {id} --force`
- [ ] Verify `/resume-task` Step 2 uses `tusk task-start <TASK_ID> --force`

🤖 Generated with [Claude Code](https://claude.com/claude-code)