### PR TITLE
[TASK-286] Remove stale relationship_type=blocks filter from dependency_health queries in tusk-insights

### DIFF
--- a/skills/tusk-insights/QUERIES.md
+++ b/skills/tusk-insights/QUERIES.md
@@ -123,7 +123,6 @@ JOIN tasks b ON d.depends_on_id = b.id
 WHERE t.status <> 'Done'
   AND b.status = 'Done'
   AND b.closed_reason IN ('wont_do', 'duplicate')
-  AND d.relationship_type = 'blocks'
 ORDER BY d.task_id;
 ```
 

--- a/skills/tusk-insights/SKILL.md
+++ b/skills/tusk-insights/SKILL.md
@@ -62,7 +62,6 @@ SELECT
     WHERE dep.status <> 'Done'
       AND blocker.status = 'Done'
       AND blocker.closed_reason IN ('wont_do', 'duplicate')
-      AND d.relationship_type = 'blocks'
   ) as dependency_health,
 
   (SELECT COUNT(*) FROM task_sessions WHERE ended_at IS NULL)


### PR DESCRIPTION
## Summary

- Removes `AND d.relationship_type = 'blocks'` from the `dependency_health` count subquery in `SKILL.md` — contingent deps on `wont_do`/`duplicate` tasks are equally stale and should count as health issues
- Removes the same filter from the `QUERIES.md` orphan tasks detail query (the companion drill-down for the same metric)
- Intentionally retains the filter in the chain depth recursive CTE — chain depth measures blocking complexity, and contingent deps don't affect task readiness, so including them would inflate depth numbers misleadingly

These three queries were identified during the TASK-284 batch but stashed to avoid scope creep; this PR resolves the remaining cleanup.

## Test plan

- [ ] Run `/tusk-insights` and verify `dependency_health` count includes tasks with `contingent` deps on `wont_do`/`duplicate` blockers
- [ ] Confirm chain depth results are unchanged (filter retained)

🤖 Generated with [Claude Code](https://claude.com/claude-code)