### PR TITLE
[TASK-287] Fix lint Rule 6 to exclude is_deferred criteria from incomplete-criteria check

### DIFF
--- a/bin/tusk-lint.py
+++ b/bin/tusk-lint.py
@@ -178,7 +178,7 @@ def rule6_done_incomplete_criteria(root):
              "SELECT t.id, t.summary, COUNT(ac.id) AS incomplete "
              "FROM tasks t "
              "JOIN acceptance_criteria ac ON ac.task_id = t.id "
-             "WHERE t.status = 'Done' AND ac.is_completed = 0 "
+             "WHERE t.status = 'Done' AND ac.is_completed = 0 AND ac.is_deferred = 0 "
              "GROUP BY t.id"],
             capture_output=True, text=True, timeout=5,
         )


### PR DESCRIPTION
## Summary

- Adds `AND ac.is_deferred = 0` to the Rule 6 WHERE clause in `bin/tusk-lint.py`
- Prevents false-positive warnings when a Done task has criteria skipped via `tusk criteria skip`
- `tusk lint` now correctly ignores intentionally-deferred criteria when checking for incomplete acceptance criteria

## Test plan

- [ ] Run `tusk lint` — Rule 6 should pass with no violations
- [ ] Verify a Done task with a deferred criterion (`is_deferred = 1`) does not appear as a Rule 6 violation

🤖 Generated with [Claude Code](https://claude.com/claude-code)