### PR TITLE
[TASK-291] Add Rule 12: py_compile syntax check for bin/tusk-*.py

### DIFF
--- a/bin/tusk-lint.py
+++ b/bin/tusk-lint.py
@@ -420,13 +420,13 @@ def rule12_python_syntax(root):
         try:
             result = subprocess.run(
                 ["python3", "-m", "py_compile", full],
-                capture_output=True, text=True, timeout=10,
+                capture_output=True, text=True, timeout=5,
             )
             if result.returncode != 0:
                 err = result.stderr.strip()
                 # Extract line number from "File ..., line N" in the traceback
                 line_match = re.search(r"line (\d+)", err)
-                line_info = f":{line_match.group(1)}" if line_match else ""
+                line_info = f":{line_match.group(1)}" if line_match else ":(unknown line)"
                 # Surface the last (most informative) line of the error
                 last_line = err.splitlines()[-1] if err else "SyntaxError"
                 violations.append(f"  {rel}{line_info}: {last_line}")


### PR DESCRIPTION
## Summary

- Adds Rule 12 to `tusk-lint.py` that runs `python3 -m py_compile` on every `bin/tusk-*.py` file
- Guards the rule with `shutil.which("python3")` so it silently skips if python3 is unavailable
- Reports file path and line number extracted from py_compile's stderr output
- Preserves the advisory-only exit semantics of `tusk lint` (exits 1 only on violations)

This closes a gap that allowed compile-time Python errors (f-string backslash violations, unterminated strings, etc.) to reach main undetected — as happened with the criteria_script line in tusk-dashboard.py in PR #250.

## Test plan

- [x] `tusk lint` runs to completion with Rule 12 PASS on all current scripts
- [x] py_compile smoke test confirms exit 1 + file/line output on a deliberately broken file
- [x] All 4 acceptance criteria marked done

🤖 Generated with [Claude Code](https://claude.com/claude-code)