### PR TITLE
[TASK-306] Remove orphaned CSS section comment in tusk-dashboard.py

### DIFF
--- a/bin/tusk-dashboard.py
+++ b/bin/tusk-dashboard.py
@@ -2075,8 +2075,6 @@ tbody tr {
   }
 }
 
-/* ── Shared stat-card strip (skill-runs + tool-calls sections) ── */
-
 /* Utility: muted text color — pairs with the --text-muted CSS variable */
 .text-muted {
   color: var(--text-muted);


### PR DESCRIPTION
## Summary
- Removes the orphaned `/* ── Shared stat-card strip (skill-runs + tool-calls sections) ── */` comment from `generate_css()` in `bin/tusk-dashboard.py`
- This comment was left behind after the TASK-305 refactor removed the `dash-stat-*` CSS block it introduced; no CSS rules followed it

## Test plan
- [ ] Verify `tusk dashboard` generates valid HTML without the comment
- [ ] Confirm no remaining references to the removed comment in the file

🤖 Generated with [Claude Code](https://claude.com/claude-code)