### PR TITLE
[TASK-311] Fix per-task tool stats double-counting criterion rows in dashboard

### DIFF
--- a/bin/tusk-dashboard.py
+++ b/bin/tusk-dashboard.py
@@ -260,6 +260,7 @@ def fetch_tool_call_stats_per_task(conn: sqlite3.Connection) -> list[dict]:
                FROM tool_call_stats tcs
                LEFT JOIN tasks t ON tcs.task_id = t.id
                WHERE tcs.task_id IS NOT NULL
+                 AND tcs.session_id IS NOT NULL
                GROUP BY tcs.task_id, tcs.tool_name
                ORDER BY tcs.task_id, total_cost DESC"""
         ).fetchall()


### PR DESCRIPTION
## Summary

- `fetch_tool_call_stats_per_task()` was aggregating all `tool_call_stats` rows with `task_id IS NOT NULL`, which after TASK-309 includes criterion-scoped rows (which have `task_id` set but no `session_id`)
- Added `AND session_id IS NOT NULL` to keep the per-task breakdown panel session-scoped only, preventing criterion-row costs from being double-counted

## Test plan

- [ ] Generate a dashboard and verify the per-task tool-cost drilldown panel no longer inflates costs from criterion rows
- [ ] Confirm criterion-scoped rows still appear correctly under their own drilldown (via `fetch_tool_call_stats_per_criterion`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)