### PR TITLE
[TASK-302] Optimize call-breakdown --task from O(sessions×transcripts) to O(transcripts)

### DIFF
--- a/bin/tusk-pricing-lib.py
+++ b/bin/tusk-pricing-lib.py
@@ -281,10 +281,11 @@ def iter_tool_call_costs(
     """Iterate per-tool-call cost attribution within a transcript time window.
 
     Yields one dict per tool_use block found in assistant messages:
-        tool_name             (str)   — tool identifier
-        marginal_input_tokens (int)   — non-cached input tokens attributed to this call
-        output_tokens         (int)   — output tokens attributed to this call
-        cost                  (float) — dollars attributed to this call
+        tool_name             (str)      — tool identifier
+        marginal_input_tokens (int)      — non-cached input tokens attributed to this call
+        output_tokens         (int)      — output tokens attributed to this call
+        cost                  (float)    — dollars attributed to this call
+        ts                    (datetime) — tz-aware timestamp of the assistant message
 
     When a single assistant message contains N tool_use blocks, tokens and
     cost are split evenly across them (floor-division for token counts).


### PR DESCRIPTION
## Summary
- `--task` mode previously re-read every transcript file once per session (O(sessions × transcripts)). With 398 transcripts and 3 sessions per task this means 1,194 file reads per invocation.
- Adds `_aggregate_sessions_single_pass` to `tusk-call-breakdown.py`: reads each transcript once, uses the new `"ts"` field on items yielded by `iter_tool_call_costs` to route each tool call to the correct session window.
- Adds `"ts": ts` to the dict yielded by `iter_tool_call_costs` in `tusk-pricing-lib.py` (non-breaking — existing callers ignore unknown keys).
- `--session`, `--skill-run`, and `--criterion` modes are unchanged.

## Test plan
- [x] `tusk call-breakdown --task 75` (3 sessions) produces correct output with new path
- [x] `tusk call-breakdown --task 314` (1 session) correct output
- [x] `tusk call-breakdown --session 268` (unchanged path) still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)