### PR TITLE
[TASK-316] tusk branch warns and skips creation when feature branch already exists

### DIFF
--- a/bin/tusk-branch.py
+++ b/bin/tusk-branch.py
@@ -110,6 +110,8 @@ def main(argv: list[str]) -> int:
             f"Delete all but one before running tusk branch.",
             file=sys.stderr,
         )
+        if dirty:
+            run(["git", "stash", "pop"], check=False)
         return 2
     elif existing_branches:
         existing_branch = existing_branches[0]


### PR DESCRIPTION
## Summary

- Checks for an existing `feature/TASK-<id>-*` branch before running `git checkout -b`
- If one is found, prints a warning to stderr and switches to it instead of creating a duplicate
- Includes guidance in the warning on how to delete the stale branch if a fresh one is needed

## Problem

`tusk-branch.py` ran `git checkout -b feature/TASK-<id>-<slug>` without checking if a matching branch already existed. This caused stale commits from prior sessions to appear in PR diffs (surfaced in TASK-315).

## Test plan

- [ ] Run `tusk branch <id> <slug>` twice with the same task ID — second call should warn and switch, not create a new branch
- [ ] Run `tusk branch <id> <different-slug>` — should detect the existing `feature/TASK-<id>-*` branch regardless of slug name

🤖 Generated with [Claude Code](https://claude.com/claude-code)