### PR TITLE
[TASK-317] Polish global tool costs panel

### DIFF
--- a/bin/tusk-dashboard.py
+++ b/bin/tusk-dashboard.py
@@ -2565,7 +2565,8 @@ def generate_global_tool_costs_section(tool_stats: list[dict]) -> str:
     """Generate a project-wide tool cost aggregate table for the Skills tab.
 
     Shows tool_name, total_calls, total_cost, and share of total across all
-    task sessions. Returns an empty string when no data is available.
+    task sessions. Returns a placeholder panel with onboarding instructions
+    when no data is available.
     """
     if not tool_stats:
         return """\


### PR DESCRIPTION
## Summary
- Remove dead `if tool_stats else` branches in Costliest Tool KPI card — unreachable after the early-return guard at the top of `generate_global_tool_costs_section()`
- Drop `MAX(max_cost)` from `fetch_tool_call_stats_global()` SELECT — column was fetched but never read by the renderer
- Add `int()` cast for `calls` variable in `generate_global_tool_costs_section()` row loop — consistent with `_generate_tool_stats_panel()` pattern
- Add empty-state message when `tool_call_global` is empty so users know to run `tusk session-close` to populate the panel

## Test plan
- [ ] Verify dashboard renders correctly when tool_call_stats has data (KPI card shows costliest tool name without ternary noise)
- [ ] Verify empty-state message appears when no session tool stats exist
- [ ] Verify call counts render as integers (no float formatting)

🤖 Generated with [Claude Code](https://claude.com/claude-code)