### PR TITLE
[TASK-323] Normalize companion modules: strip <script> wrapper from tusk-dashboard-js.py

### DIFF
--- a/bin/tusk-dashboard-js.py
+++ b/bin/tusk-dashboard-js.py
@@ -4,7 +4,6 @@ Extracted from generate_js() to reduce the main file size.
 """
 
 JS: str = """\
-<script>
 (function() {
   var body = document.getElementById('metricsBody');
   if (!body) return;
@@ -1029,5 +1028,4 @@ JS: str = """\
     document.getElementById('dagSbMetrics').innerHTML = m;
   };
 })();
-</script>
 """

--- a/bin/tusk-dashboard.py
+++ b/bin/tusk-dashboard.py
@@ -1672,7 +1672,7 @@ var DAG_MERMAID_ALL = {mermaid_all_json};
 
 def generate_js() -> str:
     """Generate all dashboard JavaScript."""
-    return _load_dashboard_js_module().JS
+    return '<script>\n' + _load_dashboard_js_module().JS + '\n</script>'
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Strips the `<script>` and `</script>` wrapper lines from the `JS` constant in `tusk-dashboard-js.py`, leaving bare JS content (matching the pattern used by `tusk-dashboard-css.py` for CSS)
- Updates `generate_js()` in `tusk-dashboard.py` to wrap the returned content: `'<script>\n' + JS + '\n</script>'`
- HTML output is identical before and after the change

## Test plan

- [ ] Verify `tusk-dashboard-js.py` JS constant does not contain `<script>` or `</script>` tags
- [ ] Verify `generate_js()` returns a string starting with `<script>` and ending with `</script>`
- [ ] Run `tusk dashboard` and confirm the generated HTML renders correctly in the browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)