### PR TITLE
[TASK-324] Make generate_css() and generate_js() symmetric: both wrap with HTML tags internally

### DIFF
--- a/bin/tusk-dashboard.py
+++ b/bin/tusk-dashboard.py
@@ -688,7 +688,7 @@ def format_relative_time(dt_str) -> str:
 # ---------------------------------------------------------------------------
 
 def generate_css() -> str:
-    """Generate the full CSS with design system tokens."""
+    """Generate the full CSS wrapped in a <style> block."""
     return '<style>\n' + _load_dashboard_css_module().CSS + '\n</style>'
 
 


### PR DESCRIPTION
## Summary

- `generate_css()` now returns `'<style>\n' + CSS + '\n</style>'` instead of bare CSS
- The HTML template f-string replaced `<style>\n{css}\n</style>` with bare `{css}`
- Both generator functions now own their HTML wrapper tag, matching the existing `generate_js()` contract

## Test plan

- [ ] Run `tusk dashboard` and verify the generated HTML contains a `<style>` block with the CSS content

🤖 Generated with [Claude Code](https://claude.com/claude-code)