### PR TITLE
[TASK-331] Add concise caller reference to check-dupes/SKILL.md

### DIFF
--- a/skills/check-dupes/SKILL.md
+++ b/skills/check-dupes/SKILL.md
@@ -10,7 +10,7 @@ Fast, deterministic pre-filter for textual near-matches. Uses character-level (S
 
 **Limitation:** This heuristic catches near-identical wording but misses semantic duplicates (e.g., "Implement password reset flow" vs. "Add forgot password endpoint"). Skills that insert tasks (`/create-task`, `/retro`) should also review the existing backlog for semantic overlap during their analysis phase — the heuristic is a supplement, not a replacement, for LLM-based semantic review.
 
-**Callers:** `/tusk` runs `check` before creating deferred tasks from PR reviews; `/create-task` and `/retro` run `check` before each insert; `/groom-backlog` runs `scan` during its duplicate sweep.
+**Callers:** `/retro` runs `check` explicitly before each insert; `/create-task` and `/review-pr` rely on `tusk task-insert` which runs the check internally; `/groom-backlog` runs `scan` during its duplicate sweep.
 
 ## Usage
 


### PR DESCRIPTION
## Summary
- Adds a single **Callers** line to `check-dupes/SKILL.md` summarizing which skills invoke this skill and which subcommand they use
- Replaces the removed Integration Points section without reverting to the verbose original

## Test plan
- [ ] Read `skills/check-dupes/SKILL.md` and verify the Callers line is present and accurate
- [ ] Confirm the section is concise (one line, not a full section) and does not duplicate the existing per-command "When to use" notes

🤖 Generated with [Claude Code](https://claude.com/claude-code)