### PR TITLE
[TASK-348] Document single-VERSION-per-PR convention

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -479,6 +479,8 @@ Commit the bump in the same branch as the feature — not as a separate PR. The 
 
 When bumping `VERSION`, also update `CHANGELOG.md` in the same commit. Add an entry under a new `## [<version>] - <YYYY-MM-DD>` heading describing what changed. Use the [Keep a Changelog](https://keepachangelog.com/) categories (`Added`, `Changed`, `Fixed`, `Removed`) and keep descriptions to one line each.
 
+**One VERSION bump per PR.** A PR should increment VERSION exactly once and have exactly one CHANGELOG entry. If iterative development within a branch creates multiple intermediate bumps, consolidate them to a single final version number before merging — the changelog history should reflect one entry per PR, not one entry per commit.
+
 ## Key Conventions
 
 - All DB access goes through `bin/tusk`, never raw `sqlite3`


### PR DESCRIPTION
## Summary
- Adds explicit "one VERSION bump per PR" rule to CLAUDE.md under the `### Changelog` subsection of `## VERSION Bumps`
- Adds matching convention to the DB via `tusk conventions add` for discoverability at runtime

## Test plan
- [ ] Verify CLAUDE.md VERSION Bumps section contains the new guidance
- [ ] Verify `tusk conventions` output includes the new entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)