### PR TITLE
[TASK-715] Auto-prioritize skill-patch tasks from retro-signals

### DIFF
--- a/.claude/tusk-manifest.json
+++ b/.claude/tusk-manifest.json
@@ -74,6 +74,7 @@
   ".claude/bin/tusk-session-stats.py",
   ".claude/bin/tusk-setup.py",
   ".claude/bin/tusk-skill-drift.py",
+  ".claude/bin/tusk-skill-patch-priority.py",
   ".claude/bin/tusk-skill-run.py",
   ".claude/bin/tusk-sync-main.py",
   ".claude/bin/tusk-sync-skills.py",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -94,6 +94,7 @@ bin/tusk autoclose
 bin/tusk backlog-scan [--duplicates] [--unassigned] [--unsized] [--expired]   # → {duplicates:[...], unassigned:[...], unsized:[...], expired:[...]}
 bin/tusk retro-signals <task_id>   # → {task_id, complexity, reopen_count, rework_chain:{fixes,fixed_by}, review_themes, skipped_criteria, tool_call_outliers, unconsumed_next_steps}
 bin/tusk retro-patches [--window-days N] [--unconfirmed]   # → [{finding_id, skill_run_id, task_id, action_taken, target_file, created_at, age_days}, ...] — list `skill-patch:<file>` retro_findings; `--unconfirmed` filters to those without a later `skill-patch-confirmed:<file>` row (issue #540)
+bin/tusk skill-patch-priority <task_id> [--apply] [--format json|text]   # → compute a priority for a skill-patch follow-up task from its retro-signals (reopen_count + rework_chain.fixes/fixed_by + review_themes recurrence → a "pressure" score; higher pressure climbs the config `priorities` ladder, zero pressure stays at the default rung). --apply persists it onto the task. Wired into /retro (at deferred skill-patch task creation) and /groom-backlog (reprioritization) so skill-patch tasks no longer rot at unmodified default priority (TASK-715)
 bin/tusk test-detect               # → {"command": "<cmd>", "confidence": "high|medium|low|none"}
 bin/tusk add-lib [--lib <name>] [--repo <owner/repo>] [--ref <branch|tag|sha>]  # → {"lib": "<name>", "tasks": [...], "error": null}
 bin/tusk init-fetch-bootstrap      # → {"libs": [{name, repo, tasks, error}, ...]}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -95,6 +95,7 @@ bin/tusk autoclose
 bin/tusk backlog-scan [--duplicates] [--unassigned] [--unsized] [--expired]   # → {duplicates:[...], unassigned:[...], unsized:[...], expired:[...]}
 bin/tusk retro-signals <task_id>   # → {task_id, complexity, reopen_count, rework_chain:{fixes,fixed_by}, review_themes, skipped_criteria, tool_call_outliers, unconsumed_next_steps}
 bin/tusk retro-patches [--window-days N] [--unconfirmed]   # → [{finding_id, skill_run_id, task_id, action_taken, target_file, created_at, age_days}, ...] — list `skill-patch:<file>` retro_findings; `--unconfirmed` filters to those without a later `skill-patch-confirmed:<file>` row (issue #540)
+bin/tusk skill-patch-priority <task_id> [--apply] [--format json|text]   # → compute a priority for a skill-patch follow-up task from its retro-signals (reopen_count + rework_chain.fixes/fixed_by + review_themes recurrence → a "pressure" score; higher pressure climbs the config `priorities` ladder, zero pressure stays at the default rung). --apply persists it onto the task. Wired into /retro (at deferred skill-patch task creation) and /groom-backlog (reprioritization) so skill-patch tasks no longer rot at unmodified default priority (TASK-715)
 bin/tusk test-detect               # → {"command": "<cmd>", "confidence": "high|medium|low|none"}
 bin/tusk add-lib [--lib <name>] [--repo <owner/repo>] [--ref <branch|tag|sha>]  # → {"lib": "<name>", "tasks": [...], "error": null}
 bin/tusk init-fetch-bootstrap      # → {"libs": [{name, repo, tasks, error}, ...]}

--- a/MANIFEST
+++ b/MANIFEST
@@ -74,6 +74,7 @@
   ".claude/bin/tusk-session-stats.py",
   ".claude/bin/tusk-setup.py",
   ".claude/bin/tusk-skill-drift.py",
+  ".claude/bin/tusk-skill-patch-priority.py",
   ".claude/bin/tusk-skill-run.py",
   ".claude/bin/tusk-sync-main.py",
   ".claude/bin/tusk-sync-skills.py",

--- a/bin/tusk
+++ b/bin/tusk
@@ -1365,7 +1365,7 @@ candidates = [
   'active-project','git-default-branch','branch-parse',
   'task-get','task-get-multi','task-select','task-start','task-done','task-insert','task-update','task-reopen','task-unstart','task-list','task-summary','task-brief','task-worktree',
   'audit','insights','autoclose','backlog-scan','groom','check-deliverables','scope-paths','scope','scope-hint',
-  'retro','retro-signals','retro-themes','retro-finding','retro-patches',
+  'retro','retro-signals','retro-themes','retro-finding','retro-patches','skill-patch-priority',
   'test-detect','test-precheck','add-lib','address-issue',
   'init-scan-codebase','init-scan-todos','init-fetch-bootstrap','init-write-config','init-write-manifest-files','init-wizard','init-scaffold',
   'loop','merge','abandon','bakeoff','progress','setup',
@@ -2072,6 +2072,7 @@ case "${1:-}" in
   retro-themes) shift; exec python3 "$SCRIPT_DIR/tusk-retro-themes.py" "$DB_PATH" "$(resolve_config)" "$@" ;;
   retro-finding) shift; exec python3 "$SCRIPT_DIR/tusk-retro-finding.py" "$DB_PATH" "$(resolve_config)" "$@" ;;
   retro-patches) shift; exec python3 "$SCRIPT_DIR/tusk-retro-patches.py" "$DB_PATH" "$(resolve_config)" "$@" ;;
+  skill-patch-priority) shift; exec python3 "$SCRIPT_DIR/tusk-skill-patch-priority.py" "$DB_PATH" "$(resolve_config)" "$@" ;;
   retro) shift; exec python3 "$SCRIPT_DIR/tusk-retro.py" "$DB_PATH" "$(resolve_config)" "$@" ;;
   test-detect) shift; exec python3 "$SCRIPT_DIR/tusk-test-detect.py" "$DB_PATH" "$(resolve_config)" "$@" ;;
   test-precheck) shift; exec python3 "$SCRIPT_DIR/tusk-test-precheck.py" "$REPO_ROOT" "$(resolve_config)" "$@" ;;

--- a/bin/tusk-skill-patch-priority.py
+++ b/bin/tusk-skill-patch-priority.py
@@ -1,0 +1,243 @@
+#!/usr/bin/env python3
+"""Compute (and optionally apply) a priority for a skill-patch follow-up task
+derived from its retro-signals, so these tasks no longer land at the unmodified
+default priority and rot in the backlog (TASK-715).
+
+Called by the tusk wrapper:
+    tusk skill-patch-priority <task_id> [--apply] [--format json|text]
+
+Arguments received from tusk:
+    sys.argv[1] — DB path
+    sys.argv[2] — config path
+    sys.argv[3] — task_id (integer or TASK-NNN prefix form)
+    remaining   — flags
+
+Signal → priority model
+-----------------------
+The priority is computed from a single integer "pressure" score built from the
+retro-signals that indicate a finding keeps biting:
+
+    pressure = reopen_count
+             + len(rework_chain.fixes)
+             + len(rework_chain.fixed_by)
+             + sum(theme.count for theme in review_themes)
+
+Higher reopen counts and longer rework chains (in either direction of the
+fixes_task_id FK) yield a higher pressure, and review themes that recur across
+passes add to it. The pressure is then mapped onto the project's ordered
+`priorities` list (config.default.json, highest first). A task with no pressure
+signals lands at the configured *default* priority (NOT the highest), so that
+skill-patch tasks that genuinely carry no rework history are not artificially
+inflated — but any non-zero pressure lifts the priority above default and the
+score is monotonic in the pressure inputs.
+
+Exit codes:
+    0 — success
+    1 — error (bad arguments, task not found, DB issue)
+"""
+
+import argparse
+import json
+import os
+import re
+import sqlite3
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import tusk_loader  # noqa: E402  # loads tusk-db-lib.py, tusk-json-lib.py, tusk-retro-signals.py
+
+_db_lib = tusk_loader.load("tusk-db-lib")
+_json_lib = tusk_loader.load("tusk-json-lib")
+_signals_mod = tusk_loader.load("tusk-retro-signals")
+dumps = _json_lib.dumps
+get_connection = _db_lib.get_connection
+build_signals = _signals_mod.build_signals
+
+# Fallback priority ladder (highest first) used only when config has no
+# non-empty `priorities` array. Mirrors config.default.json's default ladder.
+DEFAULT_PRIORITIES = ["Highest", "High", "Medium", "Low", "Lowest"]
+
+
+def _resolve_task_id(raw: str) -> int:
+    """Accept '5' or 'TASK-5' → 5. Raises ValueError on junk."""
+    return int(re.sub(r"^TASK-", "", raw, flags=re.IGNORECASE))
+
+
+def load_priorities(config_path: str) -> list:
+    """Return the ordered `priorities` ladder (highest first) from config,
+    falling back to DEFAULT_PRIORITIES when the config is missing/empty."""
+    try:
+        with open(config_path) as f:
+            config = json.load(f)
+    except (OSError, json.JSONDecodeError):
+        return list(DEFAULT_PRIORITIES)
+    priorities = config.get("priorities")
+    if isinstance(priorities, list) and priorities:
+        return list(priorities)
+    return list(DEFAULT_PRIORITIES)
+
+
+def compute_pressure(signals: dict) -> int:
+    """Aggregate the rework-pressure score from retro-signals.
+
+    Sums reopen_count, both directions of the rework chain, and the recurrence
+    counts of review themes. Each input contributes additively, so the result is
+    monotonic non-decreasing in every input (criterion 3341)."""
+    reopen = int(signals.get("reopen_count") or 0)
+
+    rework = signals.get("rework_chain") or {}
+    fixes = rework.get("fixes") or []
+    fixed_by = rework.get("fixed_by") or []
+    rework_count = len(fixes) + len(fixed_by)
+
+    themes = signals.get("review_themes") or []
+    theme_count = 0
+    for t in themes:
+        try:
+            theme_count += int(t.get("count") or 0)
+        except (AttributeError, TypeError, ValueError):
+            theme_count += 0
+
+    return reopen + rework_count + theme_count
+
+
+def pressure_to_priority(pressure: int, priorities: list) -> str:
+    """Map a non-negative pressure score onto the ordered priority ladder.
+
+    `priorities` is highest-first (index 0 = highest). With pressure 0 the task
+    lands at the configured *default* priority (the middle of the ladder), and
+    each additional unit of pressure steps one rung toward the highest priority,
+    saturating at index 0. The mapping is monotonic non-decreasing in pressure:
+    more pressure never yields a lower priority."""
+    if not priorities:
+        priorities = list(DEFAULT_PRIORITIES)
+    n = len(priorities)
+    # Default rung = middle of the ladder (e.g. "Medium" in the 5-rung default).
+    default_index = n // 2
+    # Each unit of pressure climbs one rung toward index 0 (highest).
+    index = default_index - max(0, pressure)
+    if index < 0:
+        index = 0
+    return priorities[index]
+
+
+def compute_priority(signals: dict, priorities: list) -> str:
+    """End-to-end: retro-signals dict → priority label string."""
+    return pressure_to_priority(compute_pressure(signals), priorities)
+
+
+def apply_priority(conn: sqlite3.Connection, task_id: int, priority: str) -> None:
+    """Persist the computed priority on the task row."""
+    conn.execute(
+        "UPDATE tasks SET priority = ?, updated_at = CURRENT_TIMESTAMP WHERE id = ?",
+        (priority, task_id),
+    )
+    conn.commit()
+
+
+def main(argv: list) -> int:
+    db_path = argv[0]
+    config_path = argv[1]
+    parser = argparse.ArgumentParser(
+        allow_abbrev=False,
+        prog="tusk skill-patch-priority",
+        description="Compute (and optionally apply) a retro-signal-derived "
+        "priority for a skill-patch follow-up task.",
+    )
+    parser.add_argument("task_id", help="Task ID (integer or TASK-NNN prefix form)")
+    parser.add_argument(
+        "--apply",
+        action="store_true",
+        help="Persist the computed priority onto the task (default: print only).",
+    )
+    parser.add_argument(
+        "--format",
+        choices=["json", "text"],
+        default="json",
+        help="Output format (default: json).",
+    )
+    args = parser.parse_args(argv[2:])
+
+    try:
+        task_id = _resolve_task_id(args.task_id)
+    except ValueError:
+        print(f"Invalid task ID: {args.task_id}", file=sys.stderr)
+        return 1
+
+    priorities = load_priorities(config_path)
+
+    try:
+        conn = get_connection(db_path)
+    except Exception as e:
+        print(
+            f"tusk skill-patch-priority: failed to open database '{db_path}': "
+            f"{type(e).__name__}: {e}",
+            file=sys.stderr,
+        )
+        return 1
+    try:
+        row = conn.execute(
+            "SELECT priority FROM tasks WHERE id = ?", (task_id,)
+        ).fetchone()
+        if not row:
+            print(f"Task {task_id} not found", file=sys.stderr)
+            return 1
+        previous_priority = row["priority"]
+
+        try:
+            signals = build_signals(conn, task_id)
+        except Exception as e:
+            print(
+                f"tusk skill-patch-priority: failed to collect signals for "
+                f"task {task_id}: {type(e).__name__}: {e}",
+                file=sys.stderr,
+            )
+            return 1
+
+        pressure = compute_pressure(signals)
+        priority = compute_priority(signals, priorities)
+
+        applied = False
+        if args.apply and priority != previous_priority:
+            apply_priority(conn, task_id, priority)
+            applied = True
+
+        payload = {
+            "task_id": task_id,
+            "previous_priority": previous_priority,
+            "priority": priority,
+            "pressure": pressure,
+            "applied": applied,
+            "reopen_count": int(signals.get("reopen_count") or 0),
+            "rework_count": len((signals.get("rework_chain") or {}).get("fixes") or [])
+            + len((signals.get("rework_chain") or {}).get("fixed_by") or []),
+            "review_theme_count": sum(
+                int(t.get("count") or 0)
+                for t in (signals.get("review_themes") or [])
+            ),
+        }
+
+        if args.format == "text":
+            verb = "applied" if applied else (
+                "unchanged" if priority == previous_priority else "computed"
+            )
+            print(
+                f"TASK-{task_id}: {previous_priority} -> {priority} "
+                f"(pressure={pressure}, {verb})"
+            )
+        else:
+            print(dumps(payload))
+        return 0
+    finally:
+        conn.close()
+
+
+if __name__ == "__main__":
+    if len(sys.argv) < 2 or not sys.argv[1].endswith(".db"):
+        print("Error: This script must be invoked via the tusk wrapper.", file=sys.stderr)
+        print(
+            "Use: tusk skill-patch-priority <task_id> [--apply] [--format json|text]",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    sys.exit(main(sys.argv[1:]))

--- a/skills/groom-backlog/SKILL.md
+++ b/skills/groom-backlog/SKILL.md
@@ -177,6 +177,12 @@ tusk task-done <id> --reason wont_do
 tusk task-update <id> --priority "<New Priority>"
 ```
 
+**Auto-prioritize skill-patch follow-up tasks.** Skill-patch follow-up tasks (created by `/retro` from deferred skill/doc-patch findings) frequently land at the unmodified default priority and rot in the backlog. For any open task that is a skill/doc-patch follow-up, derive its priority from its retro-signals — reopen counts, rework chains (fixes/fixed_by), and recurring review themes — and apply it. Higher reopen and rework counts yield a higher priority:
+```bash
+tusk skill-patch-priority <id> --apply
+```
+The command is a no-op when the task carries no rework history (it stays at default) and lifts the priority otherwise, so it is safe to run across every candidate skill-patch task. Count each task it changes toward the `tasks_reprioritized` metric in Step 7's `skill-run finish` rollup.
+
 ### For Agent Assignments:
 ```bash
 tusk task-update <id> --assignee "<agent-name>"

--- a/skills/retro/SKILL.md
+++ b/skills/retro/SKILL.md
@@ -185,6 +185,12 @@ Category A findings are always **tusk-issues**. Category D findings are normally
    ```
    Always include at least one `--criteria` flag — derive 1–3 concrete acceptance criteria from the task description. Omit `--domain` or `--assignee` entirely if the value is NULL/empty. Exit code 1 means duplicate — skip. Skip subsumption and dependency proposals.
 
+   **Auto-prioritize deferred skill-patch tasks.** When a deferred **skill/doc patch** finding (step 3f above — the task description carries a proposed diff against a skill/agent/doc file) is inserted, it would otherwise land at the unmodified default priority and rot in the backlog. Immediately after the `task-insert` returns the new task ID, derive a priority from the task's retro-signals (reopen counts, rework chains, recurring review themes — higher counts yield higher priority) and apply it:
+   ```bash
+   tusk skill-patch-priority <new_task_id> --apply
+   ```
+   This is a no-op for a brand-new task with no rework history (it stays at default), but lifts the priority when the underlying skill/doc has a history of reopens or fix-chains. Only run it for skill/doc-patch follow-ups, not for every project-issue task.
+
 ### LR-2a: Inline Convention/Doc Actions
 
 Before creating tasks for project-issue findings, check whether the approved action can be applied inline as a convention or documentation patch.

--- a/tests/unit/test_skill_patch_priority.py
+++ b/tests/unit/test_skill_patch_priority.py
@@ -1,0 +1,194 @@
+"""Unit tests for tusk-skill-patch-priority.py (TASK-715).
+
+Skill-patch follow-up tasks should land at a priority derived from their
+retro-signals (reopen counts, rework chains, review themes) rather than the
+unmodified default priority. These tests cover the three criterion node IDs
+referenced by the task's verification specs:
+
+    -k computes   → priority is computed from retro-signals
+    -k monotonic  → higher reopen/rework counts yield higher priority
+    -k applied    → the computed priority is applied to the task
+"""
+
+import importlib.util
+import os
+import sqlite3
+import sys
+
+import pytest
+
+BIN = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))),
+    "bin",
+)
+sys.path.insert(0, BIN)
+
+
+def _load_module():
+    path = os.path.join(BIN, "tusk-skill-patch-priority.py")
+    spec = importlib.util.spec_from_file_location("tusk_skill_patch_priority", path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+spp = _load_module()
+
+DEFAULT_PRIORITIES = ["Highest", "High", "Medium", "Low", "Lowest"]
+
+
+def _signals(reopen=0, fixes=0, fixed_by=0, themes=None):
+    return {
+        "task_id": 1,
+        "reopen_count": reopen,
+        "rework_chain": {
+            "fixes": [{"id": i} for i in range(fixes)],
+            "fixed_by": [{"id": i} for i in range(fixed_by)],
+        },
+        "review_themes": themes or [],
+    }
+
+
+def _priority_index(priority):
+    return DEFAULT_PRIORITIES.index(priority)
+
+
+# --------------------------------------------------------------------------
+# computes — priority is computed from retro-signals (criterion 3340)
+# --------------------------------------------------------------------------
+
+
+def test_computes_returns_a_valid_priority_label():
+    p = spp.compute_priority(_signals(), DEFAULT_PRIORITIES)
+    assert p in DEFAULT_PRIORITIES
+
+
+def test_computes_zero_pressure_lands_at_default_not_highest():
+    # No rework history → the configured default (middle) priority, NOT inflated.
+    p = spp.compute_priority(_signals(), DEFAULT_PRIORITIES)
+    assert p == "Medium"
+    assert p != "Highest"
+
+
+def test_computes_pressure_aggregates_all_signal_sources():
+    pressure = spp.compute_pressure(
+        _signals(
+            reopen=2,
+            fixes=1,
+            fixed_by=1,
+            themes=[{"count": 3}],
+        )
+    )
+    assert pressure == 2 + 1 + 1 + 3
+
+
+def test_computes_nonzero_pressure_lifts_above_default():
+    p = spp.compute_priority(_signals(reopen=1), DEFAULT_PRIORITIES)
+    assert _priority_index(p) < _priority_index("Medium")  # higher = lower index
+
+
+def test_computes_handles_missing_signal_keys_gracefully():
+    # An empty / partial signals dict must not raise and must yield default.
+    assert spp.compute_priority({}, DEFAULT_PRIORITIES) == "Medium"
+
+
+def test_computes_respects_custom_priority_ladder():
+    ladder = ["P0", "P1", "P2", "P3"]
+    p = spp.compute_priority(_signals(reopen=10), ladder)
+    assert p == "P0"  # saturates at highest
+
+
+# --------------------------------------------------------------------------
+# monotonic — higher reopen and rework counts yield higher priority (3341)
+# --------------------------------------------------------------------------
+
+
+def test_monotonic_more_reopens_never_lower_priority():
+    prev_idx = None
+    for reopen in range(0, 6):
+        p = spp.compute_priority(_signals(reopen=reopen), DEFAULT_PRIORITIES)
+        idx = _priority_index(p)
+        if prev_idx is not None:
+            assert idx <= prev_idx  # lower index == higher priority
+        prev_idx = idx
+
+
+def test_monotonic_more_rework_never_lower_priority():
+    prev_idx = None
+    for n in range(0, 6):
+        p = spp.compute_priority(
+            _signals(fixes=n, fixed_by=n), DEFAULT_PRIORITIES
+        )
+        idx = _priority_index(p)
+        if prev_idx is not None:
+            assert idx <= prev_idx
+        prev_idx = idx
+
+
+def test_monotonic_higher_reopen_strictly_outranks_zero():
+    low = spp.compute_priority(_signals(reopen=0), DEFAULT_PRIORITIES)
+    high = spp.compute_priority(_signals(reopen=3), DEFAULT_PRIORITIES)
+    assert _priority_index(high) < _priority_index(low)
+
+
+def test_monotonic_pressure_is_nondecreasing_in_each_input():
+    base = spp.compute_pressure(_signals(reopen=1, fixes=1, fixed_by=1))
+    assert spp.compute_pressure(_signals(reopen=2, fixes=1, fixed_by=1)) >= base
+    assert spp.compute_pressure(_signals(reopen=1, fixes=2, fixed_by=1)) >= base
+    assert spp.compute_pressure(_signals(reopen=1, fixes=1, fixed_by=2)) >= base
+    assert (
+        spp.compute_pressure(
+            _signals(reopen=1, fixes=1, fixed_by=1, themes=[{"count": 1}])
+        )
+        >= base
+    )
+
+
+def test_monotonic_combined_pressure_outranks_single_signal():
+    single = spp.compute_priority(_signals(reopen=1), DEFAULT_PRIORITIES)
+    combined = spp.compute_priority(
+        _signals(reopen=1, fixes=1, fixed_by=1, themes=[{"count": 2}]),
+        DEFAULT_PRIORITIES,
+    )
+    assert _priority_index(combined) <= _priority_index(single)
+
+
+# --------------------------------------------------------------------------
+# applied — the computed priority is applied to the task (criterion 3342)
+# --------------------------------------------------------------------------
+
+
+@pytest.fixture
+def conn():
+    c = sqlite3.connect(":memory:")
+    c.row_factory = sqlite3.Row
+    c.execute(
+        "CREATE TABLE tasks (id INTEGER PRIMARY KEY, priority TEXT, "
+        "updated_at TEXT DEFAULT CURRENT_TIMESTAMP)"
+    )
+    yield c
+    c.close()
+
+
+def test_applied_persists_priority_on_task(conn):
+    conn.execute("INSERT INTO tasks (id, priority) VALUES (1, 'Medium')")
+    conn.commit()
+    spp.apply_priority(conn, 1, "High")
+    row = conn.execute("SELECT priority FROM tasks WHERE id = 1").fetchone()
+    assert row["priority"] == "High"
+
+
+def test_applied_overwrites_default_priority(conn):
+    # Simulate a skill-patch task that landed at default 'Medium'.
+    conn.execute("INSERT INTO tasks (id, priority) VALUES (7, 'Medium')")
+    conn.commit()
+    signals = _signals(reopen=2, fixes=1)
+    computed = spp.compute_priority(signals, DEFAULT_PRIORITIES)
+    assert computed != "Medium"  # genuinely changes the landing priority
+    spp.apply_priority(conn, 7, computed)
+    row = conn.execute("SELECT priority FROM tasks WHERE id = 7").fetchone()
+    assert row["priority"] == computed
+
+
+def test_applied_load_priorities_falls_back_when_config_missing():
+    assert spp.load_priorities("/nonexistent/config.json") == DEFAULT_PRIORITIES


### PR DESCRIPTION
## Summary

Skill-patch follow-up tasks (created by `/retro` from deferred skill/doc-patch findings) previously landed at the unmodified default priority and rotted in the backlog. This adds `tusk skill-patch-priority <task_id> [--apply]`, which derives a priority for such a task from its retro-signals and applies it.

- **New CLI** `bin/tusk-skill-patch-priority.py` reuses `build_signals(conn, task_id)` from `tusk-retro-signals.py` and computes a single "pressure" score: `reopen_count + len(rework_chain.fixes) + len(rework_chain.fixed_by) + sum(review_themes[*].count)`. The mapping is additive, so the score is monotonic non-decreasing in every input — higher reopen and rework counts yield a higher priority.
- **Priority mapping** climbs the config `priorities` ladder (highest-first) from the default rung (middle of the ladder): pressure 0 stays at default (no artificial inflation for tasks with no rework history), each unit of pressure steps one rung toward the highest, saturating at the top.
- `--apply` persists the computed priority onto the task; without it the command prints the computed verdict only (compact JSON by default; `--format text` for humans).
- **Wired into both surfaces** so the priority is applied at creation and via grooming:
  - `/retro` runs `tusk skill-patch-priority <new_id> --apply` right after inserting a deferred skill/doc-patch task.
  - `/groom-backlog` runs it across skill-patch follow-up tasks during reprioritization, counting changes toward `tasks_reprioritized`.
- Dispatcher case + fuzzy-match candidate added to `bin/tusk`; MANIFEST / `.claude/tusk-manifest.json` regenerated; CLAUDE.md + AGENTS.md command reference updated.

## Test plan

- `tests/unit/test_skill_patch_priority.py` — 14 tests across the three criterion node IDs:
  - `computes` — priority computed from signals; zero pressure stays at default (not Highest); pressure aggregates all sources; custom ladders respected.
  - `monotonic` — more reopens / more rework never lower priority; pressure non-decreasing in each input.
  - `applied` — `apply_priority` persists onto the task row; overwrites the default landing priority; config fallback when missing.
- Full unit suite green (2198 passed). `tusk lint` clean (25 rules).

🤖 Generated with [Claude Code](https://claude.com/claude-code)