### PR TITLE
[TASK-711] Add advisory tier to DB-backed lint rules

### DIFF
--- a/bin/tusk
+++ b/bin/tusk
@@ -1173,8 +1173,10 @@ CREATE TABLE lint_rules (
     message TEXT NOT NULL,
     is_blocking INTEGER NOT NULL DEFAULT 0,
     source_skill TEXT,
+    enforcement TEXT NOT NULL DEFAULT 'enforcing',
     created_at TEXT DEFAULT (datetime('now')),
-    CHECK (is_blocking IN (0, 1))
+    CHECK (is_blocking IN (0, 1)),
+    CHECK (enforcement IN ('advisory', 'enforcing'))
 );
 LINT_RULES_SCHEMA
 
@@ -1271,7 +1273,7 @@ PRECHECK_VERDICTS_SCHEMA
   fi
 
   # Set schema version so fresh DBs never need migration
-  sqlite3 "$DB_PATH" "PRAGMA user_version = 81;"
+  sqlite3 "$DB_PATH" "PRAGMA user_version = 82;"
 
   echo "Initialized task database at $DB_PATH"
   echo "Note: tusk/tasks.db is local-only — not synced across machines."

--- a/bin/tusk-lint-rules.py
+++ b/bin/tusk-lint-rules.py
@@ -2,11 +2,13 @@
 """Manage DB-backed lint rules for tusk lint.
 
 Called by the tusk wrapper:
-    tusk lint-rule add <pattern> <file_glob> <message> [--blocking] [--skill <name>]
+    tusk lint-rule add <pattern> <file_glob> <message> [--blocking] [--advisory]
+                       [--skill <name>]
     tusk lint-rule list
     tusk lint-rule update <id> [--file-glob <glob>] [--grep-pattern <pattern>]
                                [--message <text>] [--blocking | --no-blocking]
                                [--skill <name>]
+    tusk lint-rule promote <id>
     tusk lint-rule remove <id>
 
 Arguments received from tusk:
@@ -28,14 +30,17 @@ get_connection = _db_lib.get_connection
 
 
 def cmd_add(args: argparse.Namespace, db_path: str) -> int:
+    enforcement = "advisory" if args.advisory else "enforcing"
     conn = get_connection(db_path)
     try:
         cur = conn.execute(
-            "INSERT INTO lint_rules (grep_pattern, file_glob, message, is_blocking, source_skill)"
-            " VALUES (?, ?, ?, ?, ?)",
+            "INSERT INTO lint_rules"
+            " (grep_pattern, file_glob, message, is_blocking, source_skill, enforcement)"
+            " VALUES (?, ?, ?, ?, ?, ?)",
             (args.pattern, args.file_glob, args.message,
              1 if args.blocking else 0,
-             args.skill),
+             args.skill,
+             enforcement),
         )
         conn.commit()
         print(cur.lastrowid)
@@ -48,22 +53,25 @@ def cmd_list(db_path: str) -> int:
     conn = get_connection(db_path)
     try:
         rows = conn.execute(
-            "SELECT id, grep_pattern, file_glob, message, is_blocking, source_skill, created_at"
+            "SELECT id, grep_pattern, file_glob, message, is_blocking, source_skill,"
+            " enforcement, created_at"
             " FROM lint_rules ORDER BY id"
         ).fetchall()
         if not rows:
             print("No lint rules defined.")
             return 0
-        fmt = "{:<5} {:<10} {:<20} {:<35} {}"
-        print(fmt.format("ID", "BLOCKING", "FILE_GLOB", "PATTERN", "MESSAGE"))
-        print("-" * 80)
+        fmt = "{:<5} {:<10} {:<10} {:<18} {:<30} {}"
+        print(fmt.format("ID", "BLOCKING", "ENFORCE", "FILE_GLOB", "PATTERN", "MESSAGE"))
+        print("-" * 90)
         for row in rows:
             blocking = "yes" if row["is_blocking"] else "no"
+            enforcement = row["enforcement"]
             pattern = row["grep_pattern"]
-            if len(pattern) > 33:
-                pattern = pattern[:30] + "..."
+            if len(pattern) > 28:
+                pattern = pattern[:25] + "..."
             message = row["message"]
-            print(fmt.format(row["id"], blocking, row["file_glob"], pattern, message))
+            print(fmt.format(
+                row["id"], blocking, enforcement, row["file_glob"], pattern, message))
         return 0
     finally:
         conn.close()
@@ -133,9 +141,33 @@ def cmd_remove(args: argparse.Namespace, db_path: str) -> int:
         conn.close()
 
 
+def cmd_promote(args: argparse.Namespace, db_path: str) -> int:
+    """Flip an advisory rule to enforcing once it has been observed to hold."""
+    conn = get_connection(db_path)
+    try:
+        row = conn.execute(
+            "SELECT id, enforcement FROM lint_rules WHERE id = ?", (args.id,)
+        ).fetchone()
+        if not row:
+            print(f"Error: lint rule {args.id} not found", file=sys.stderr)
+            return 2
+        if row["enforcement"] == "enforcing":
+            print(f"Lint rule {args.id} is already enforcing.")
+            return 0
+        conn.execute(
+            "UPDATE lint_rules SET enforcement = 'enforcing' WHERE id = ?",
+            (args.id,),
+        )
+        conn.commit()
+        print(f"Promoted lint rule {args.id} to enforcing.")
+        return 0
+    finally:
+        conn.close()
+
+
 def main(argv: list[str]) -> int:
     if len(argv) < 3:
-        print("Usage: tusk lint-rule {add|list|update|remove} ...", file=sys.stderr)
+        print("Usage: tusk lint-rule {add|list|update|promote|remove} ...", file=sys.stderr)
         return 2
 
     db_path = argv[1]
@@ -152,6 +184,10 @@ def main(argv: list[str]) -> int:
         parser.add_argument("message", help="violation message to display")
         parser.add_argument("--blocking", action="store_true",
                             help="make this rule blocking (counts toward lint exit code)")
+        parser.add_argument("--advisory", action="store_true",
+                            help="stage this rule advisory-only — hits warn but never gate "
+                                 "tusk lint/commit/merge until `tusk lint-rule promote` "
+                                 "flips it to enforcing")
         parser.add_argument("--skill", default=None, metavar="NAME",
                             help="skill that created this rule")
         args = parser.parse_args(argv[4:])
@@ -181,6 +217,13 @@ def main(argv: list[str]) -> int:
         args = parser.parse_args(argv[4:])
         return cmd_update(args, db_path)
 
+    elif subcommand == "promote":
+        parser = argparse.ArgumentParser(allow_abbrev=False, prog="tusk lint-rule promote")
+        parser.add_argument("id", type=int,
+                            help="rule ID to promote from advisory to enforcing")
+        args = parser.parse_args(argv[4:])
+        return cmd_promote(args, db_path)
+
     elif subcommand == "remove":
         parser = argparse.ArgumentParser(allow_abbrev=False, prog="tusk lint-rule remove")
         parser.add_argument("id", type=int, help="rule ID to remove")
@@ -189,7 +232,7 @@ def main(argv: list[str]) -> int:
 
     else:
         print(f"Unknown subcommand: {subcommand!r}", file=sys.stderr)
-        print("Usage: tusk lint-rule {add|list|update|remove} ...", file=sys.stderr)
+        print("Usage: tusk lint-rule {add|list|update|promote|remove} ...", file=sys.stderr)
         return 2
 
 

--- a/bin/tusk-lint.py
+++ b/bin/tusk-lint.py
@@ -986,19 +986,49 @@ def _db_path_from_root(root):
     return None
 
 
-def _load_lint_rules(root, is_blocking):
-    """Load lint_rules rows from the DB filtered by is_blocking. Returns [] on any failure."""
+def _load_lint_rules(root, gating):
+    """Load lint_rules rows partitioned by whether they gate the lint exit code.
+
+    A rule gates only when it is blocking AND its enforcement is 'enforcing'.
+    Two orthogonal columns drive the warn-vs-gate decision:
+      * ``is_blocking`` — whether the rule was ever meant to count toward the
+        exit code (the long-standing distinction; Rule 16 vs Rule 17).
+      * ``enforcement`` — 'advisory' stages a rule for observation so its hits
+        warn but never gate, even when ``is_blocking=1``; 'promote' flips it to
+        'enforcing' (Task 711).
+
+    Pass ``gating=True`` for the rules that count toward the exit code
+    (``is_blocking = 1 AND enforcement = 'enforcing'``) and ``gating=False`` for
+    everything else (warn-only). Returns [] on any failure.
+
+    The enforcement column predicate degrades gracefully on a pre-migration DB:
+    if the column is missing the query raises OperationalError and we retry
+    without it, so an un-migrated client still partitions purely on
+    ``is_blocking`` (advisory rules simply aren't available there yet).
+    """
     db_path = _db_path_from_root(root)
     if not db_path:
         return []
     try:
         conn = tusk_loader.load("tusk-db-lib").get_connection(db_path)
         try:
-            rows = conn.execute(
-                "SELECT id, grep_pattern, file_glob, message FROM lint_rules"
-                " WHERE is_blocking = ? ORDER BY id",
-                (1 if is_blocking else 0,),
-            ).fetchall()
+            if gating:
+                where = "is_blocking = 1 AND enforcement = 'enforcing'"
+            else:
+                where = "NOT (is_blocking = 1 AND enforcement = 'enforcing')"
+            try:
+                rows = conn.execute(
+                    "SELECT id, grep_pattern, file_glob, message FROM lint_rules"
+                    f" WHERE {where} ORDER BY id"
+                ).fetchall()
+            except sqlite3.OperationalError:
+                # Pre-migration DB without the enforcement column — fall back to
+                # the is_blocking-only partition.
+                rows = conn.execute(
+                    "SELECT id, grep_pattern, file_glob, message FROM lint_rules"
+                    " WHERE is_blocking = ? ORDER BY id",
+                    (1 if gating else 0,),
+                ).fetchall()
             return [dict(r) for r in rows]
         except sqlite3.OperationalError:
             return []  # lint_rules table not yet created (pre-migration DB)
@@ -1052,14 +1082,24 @@ def _run_lint_rules(root, rules):
 
 
 def rule16_db_rules_blocking(root):
-    """DB-backed lint rules with is_blocking=1 (count toward exit code)."""
-    rules = _load_lint_rules(root, is_blocking=True)
+    """DB-backed lint rules that gate the exit code.
+
+    A rule gates only when ``is_blocking=1 AND enforcement='enforcing'`` — an
+    advisory-enforcement rule, even if blocking, falls through to Rule 17 and
+    warns instead of gating (Task 711).
+    """
+    rules = _load_lint_rules(root, gating=True)
     return _run_lint_rules(root, rules)
 
 
 def rule17_db_rules_advisory(root):
-    """DB-backed lint rules with is_blocking=0 (advisory warnings only)."""
-    rules = _load_lint_rules(root, is_blocking=False)
+    """DB-backed lint rules that warn only (advisory warnings).
+
+    Covers everything that is NOT (``is_blocking=1 AND enforcement='enforcing'``):
+    non-blocking rules and blocking rules still staged at
+    ``enforcement='advisory'`` (Task 711).
+    """
+    rules = _load_lint_rules(root, gating=False)
     return _run_lint_rules(root, rules)
 
 

--- a/bin/tusk-migrate.py
+++ b/bin/tusk-migrate.py
@@ -3510,6 +3510,39 @@ def migrate_81(db_path: str, config_path: str, script_dir: str) -> None:
     _progress("  Migration 81: added precheck_verdicts table")
 
 
+def migrate_82(db_path: str, config_path: str, script_dir: str) -> None:
+    """Add lint_rules.enforcement so a rule can be staged advisory-only.
+
+    Task 711: today a DB-backed lint rule gates the moment it is added (a
+    blocking rule counts toward the lint exit code, so it blocks tusk commit
+    and tusk merge immediately). That leaves no way to stage a newly-discovered
+    anti-pattern for observation before it starts blocking. The orthogonal
+    `enforcement` column ('advisory'|'enforcing', default 'enforcing') lets a
+    rule warn-only until `tusk lint-rule promote` flips it to enforcing once it
+    has been observed to hold. This is the foundation for auto-proposing rules
+    from retro output. No views project lint_rules columns, so none need
+    recreating.
+
+    Idempotent: guarded with has_column; re-running is a no-op after the column
+    exists. Existing rows default to 'enforcing' so behavior is unchanged for
+    rules added before this migration.
+    """
+    if get_version(db_path) >= 82:
+        _progress("  Migration 82: added lint_rules.enforcement")
+        return
+
+    if not has_column(db_path, "lint_rules", "enforcement"):
+        run_script(
+            db_path,
+            "ALTER TABLE lint_rules ADD COLUMN enforcement TEXT NOT NULL"
+            " DEFAULT 'enforcing'"
+            " CHECK (enforcement IN ('advisory', 'enforcing'));",
+        )
+
+    set_version(db_path, 82)
+    _progress("  Migration 82: added lint_rules.enforcement")
+
+
 # ── Migration registry ────────────────────────────────────────────────────────
 
 MIGRATIONS = [
@@ -3594,6 +3627,7 @@ MIGRATIONS = [
     (79, migrate_79),
     (80, migrate_80),
     (81, migrate_81),
+    (82, migrate_82),
 ]
 
 

--- a/docs/DOMAIN.md
+++ b/docs/DOMAIN.md
@@ -614,7 +614,9 @@ A generalizable heuristic or rule captured for the project. Managed via `tusk co
 
 ### Lint Rule
 
-A DB-backed grep rule that `tusk lint` runs alongside its hardcoded rules. Rules are managed via `tusk lint-rule add/list/remove` and created by skills or users. Advisory rules emit `WARN [ADVISORY]`; blocking rules contribute to the non-zero exit code.
+A DB-backed grep rule that `tusk lint` runs alongside its hardcoded rules. Rules are managed via `tusk lint-rule add/list/update/promote/remove` and created by skills or users. A rule's hits gate the lint exit code (and therefore `tusk commit`/`tusk merge`) only when `is_blocking = 1 AND enforcement = 'enforcing'`; everything else emits `WARN [ADVISORY]` and does not contribute to the non-zero exit code.
+
+`is_blocking` and `enforcement` are **orthogonal**: `is_blocking` is the long-standing distinction between Rule 16 (gating) and Rule 17 (advisory) candidates, while `enforcement` lets a newly-discovered anti-pattern be staged for observation — added with `tusk lint-rule add --advisory`, a rule warns but never gates even if `is_blocking=1`, until `tusk lint-rule promote <id>` flips it to `enforcing` once it has been observed to hold. This is the foundation for auto-proposing rules from retro output (Task 711).
 
 | Attribute | Type | Constraints | Description |
 |-----------|------|-------------|-------------|
@@ -622,8 +624,9 @@ A DB-backed grep rule that `tusk lint` runs alongside its hardcoded rules. Rules
 | `grep_pattern` | TEXT | NOT NULL | Extended regex pattern (`grep -E`) to search for |
 | `file_glob` | TEXT | NOT NULL | Glob pattern for files to search (e.g. `**/*.py`, `skills/**/*.md`) |
 | `message` | TEXT | NOT NULL | Violation message shown when the pattern is found |
-| `is_blocking` | INTEGER | CHECK IN (0, 1); NOT NULL, default 0 | 1 = counts toward lint exit code; 0 = advisory warning only |
+| `is_blocking` | INTEGER | CHECK IN (0, 1); NOT NULL, default 0 | 1 = candidate to count toward lint exit code; 0 = advisory warning only |
 | `source_skill` | TEXT | nullable | Skill that created this rule (e.g. `lint-conventions`) |
+| `enforcement` | TEXT | CHECK IN ('advisory', 'enforcing'); NOT NULL, default 'enforcing' | `'enforcing'` = a blocking rule's hits gate the exit code; `'advisory'` = staged for observation, hits warn but never gate even when `is_blocking=1`. Flip via `tusk lint-rule promote`. |
 | `created_at` | TEXT | default now | When the rule was added |
 
 ---

--- a/tests/integration/test_lint_rule_advisory.py
+++ b/tests/integration/test_lint_rule_advisory.py
@@ -1,0 +1,151 @@
+"""Integration test for migration 82: lint_rules.enforcement column (Task 711).
+
+Selected by criterion 3322 via `-k migration`.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import sqlite3
+
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+MIGRATE_PATH = os.path.join(REPO_ROOT, "bin", "tusk-migrate.py")
+
+_spec = importlib.util.spec_from_file_location("tusk_migrate", MIGRATE_PATH)
+tusk_migrate = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(tusk_migrate)
+
+
+def _downgrade_to_v81(db_path) -> None:
+    """Drop the enforcement column and stamp v81 to simulate a pre-82 DB.
+
+    SQLite cannot DROP COLUMN on every supported version, so rebuild the table
+    without the column.
+    """
+    conn = sqlite3.connect(str(db_path))
+    try:
+        conn.executescript(
+            """
+            DROP TABLE IF EXISTS lint_rules;
+            CREATE TABLE lint_rules (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                grep_pattern TEXT NOT NULL,
+                file_glob TEXT NOT NULL,
+                message TEXT NOT NULL,
+                is_blocking INTEGER NOT NULL DEFAULT 0,
+                source_skill TEXT,
+                created_at TEXT DEFAULT (datetime('now')),
+                CHECK (is_blocking IN (0, 1))
+            );
+            PRAGMA user_version = 81;
+            """
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def _table_columns(db_path, table) -> dict:
+    conn = sqlite3.connect(str(db_path))
+    try:
+        rows = conn.execute(f"PRAGMA table_info({table})").fetchall()
+    finally:
+        conn.close()
+    return {r[1]: r[2] for r in rows}  # name -> declared type
+
+
+def test_migration_adds_enforcement_column(db_path, config_path):
+    _downgrade_to_v81(db_path)
+    assert "enforcement" not in _table_columns(db_path, "lint_rules")
+
+    tusk_migrate.migrate_82(str(db_path), str(config_path), os.path.join(REPO_ROOT, "bin"))
+
+    cols = _table_columns(db_path, "lint_rules")
+    assert "enforcement" in cols, "migration 82 must add lint_rules.enforcement"
+
+    conn = sqlite3.connect(str(db_path))
+    try:
+        version = conn.execute("PRAGMA user_version").fetchone()[0]
+        # Default for new rows must be 'enforcing' (behavior unchanged for
+        # rules that don't opt into the advisory tier).
+        conn.execute(
+            "INSERT INTO lint_rules (grep_pattern, file_glob, message)"
+            " VALUES ('p', '**/*.py', 'm')"
+        )
+        conn.commit()
+        enforcement = conn.execute(
+            "SELECT enforcement FROM lint_rules ORDER BY id DESC LIMIT 1"
+        ).fetchone()[0]
+    finally:
+        conn.close()
+    assert version == 82
+    assert enforcement == "enforcing"
+
+
+def test_migration_check_constraint_rejects_bad_enforcement(db_path, config_path):
+    _downgrade_to_v81(db_path)
+    tusk_migrate.migrate_82(str(db_path), str(config_path), os.path.join(REPO_ROOT, "bin"))
+
+    conn = sqlite3.connect(str(db_path))
+    try:
+        # 'advisory' is accepted ...
+        conn.execute(
+            "INSERT INTO lint_rules (grep_pattern, file_glob, message, enforcement)"
+            " VALUES ('p', '**/*.py', 'm', 'advisory')"
+        )
+        conn.commit()
+        # ... an out-of-domain value is rejected by the CHECK constraint.
+        import pytest
+
+        with pytest.raises(sqlite3.IntegrityError):
+            conn.execute(
+                "INSERT INTO lint_rules (grep_pattern, file_glob, message, enforcement)"
+                " VALUES ('p', '**/*.py', 'm', 'bogus')"
+            )
+            conn.commit()
+    finally:
+        conn.close()
+
+
+def test_migration_fresh_init_at_or_past_v82(db_path):
+    # cmd_init stamps the latest schema version; the column must exist on a
+    # fresh DB without running the migration.
+    cols = _table_columns(db_path, "lint_rules")
+    assert "enforcement" in cols, "fresh init should create lint_rules.enforcement"
+    conn = sqlite3.connect(str(db_path))
+    try:
+        version = conn.execute("PRAGMA user_version").fetchone()[0]
+    finally:
+        conn.close()
+    assert version >= 82
+
+
+def test_migration_idempotent_when_already_at_v82(db_path, config_path):
+    # Fresh DBs initialize at the latest schema; stamp 82 explicitly so this
+    # test keeps passing when later migrations land (see CLAUDE.md checklist).
+    conn = sqlite3.connect(str(db_path))
+    try:
+        conn.execute("PRAGMA user_version = 82")
+        conn.execute(
+            "INSERT INTO lint_rules (grep_pattern, file_glob, message, enforcement)"
+            " VALUES ('p', '**/*.py', 'm', 'advisory')"
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    # Re-running must not drop the column or lose the row.
+    tusk_migrate.migrate_82(str(db_path), str(config_path), os.path.join(REPO_ROOT, "bin"))
+
+    conn = sqlite3.connect(str(db_path))
+    try:
+        count = conn.execute(
+            "SELECT COUNT(*) FROM lint_rules WHERE enforcement = 'advisory'"
+        ).fetchone()[0]
+        version = conn.execute("PRAGMA user_version").fetchone()[0]
+    finally:
+        conn.close()
+    assert count == 1
+    assert version >= 82

--- a/tests/unit/test_lint_rule_advisory.py
+++ b/tests/unit/test_lint_rule_advisory.py
@@ -1,0 +1,245 @@
+"""Unit tests for the advisory enforcement tier of DB-backed lint rules (Task 711).
+
+Two orthogonal columns drive the warn-vs-gate decision on a ``lint_rules`` row:
+
+* ``is_blocking`` — the long-standing distinction between gating (Rule 16) and
+  advisory (Rule 17) candidates.
+* ``enforcement`` — ``'advisory'`` stages a rule for observation so its hits
+  warn but never gate, even when ``is_blocking=1``; ``'enforcing'`` lets a
+  blocking rule gate the lint exit code.
+
+A rule gates only when ``is_blocking = 1 AND enforcement = 'enforcing'``.
+
+Coverage:
+* ``advisory_no_gate`` — a blocking rule staged ``enforcement='advisory'`` does
+  not flow into the gating bucket (Rule 16), so it cannot fail the lint gate.
+* ``advisory_warns`` — that same advisory rule still flows into the warn-only
+  bucket (Rule 17), so its hits are reported as warnings.
+* ``promote`` — ``tusk lint-rule promote`` flips advisory → enforcing (and is a
+  no-op / error on the edge cases).
+"""
+
+import importlib.util
+import os
+import sqlite3
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+BIN = os.path.join(REPO_ROOT, "bin")
+
+_lint_spec = importlib.util.spec_from_file_location(
+    "tusk_lint", os.path.join(BIN, "tusk-lint.py")
+)
+lint = importlib.util.module_from_spec(_lint_spec)
+_lint_spec.loader.exec_module(lint)
+
+_rules_spec = importlib.util.spec_from_file_location(
+    "tusk_lint_rules", os.path.join(BIN, "tusk-lint-rules.py")
+)
+rules_mod = importlib.util.module_from_spec(_rules_spec)
+_rules_spec.loader.exec_module(rules_mod)
+
+
+# Mirror the post-migration lint_rules schema (bin/tusk cmd_init + migration 82).
+_LINT_RULES_SCHEMA = """
+CREATE TABLE lint_rules (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    grep_pattern TEXT NOT NULL,
+    file_glob TEXT NOT NULL,
+    message TEXT NOT NULL,
+    is_blocking INTEGER NOT NULL DEFAULT 0,
+    source_skill TEXT,
+    enforcement TEXT NOT NULL DEFAULT 'enforcing',
+    created_at TEXT DEFAULT (datetime('now')),
+    CHECK (is_blocking IN (0, 1)),
+    CHECK (enforcement IN ('advisory', 'enforcing'))
+);
+"""
+
+# A pattern that matches a sentinel line we plant in a tmp file.
+_PATTERN = "FORBIDDEN_TOKEN"
+_FLAGGED_LINE = "x = FORBIDDEN_TOKEN  # planted\n"
+
+
+def _make_db(tmp_path, *, is_blocking, enforcement) -> str:
+    """Create a tmp DB seeded with one lint_rule row and return its path."""
+    db_path = str(tmp_path / "tasks.db")
+    conn = sqlite3.connect(db_path)
+    conn.executescript(_LINT_RULES_SCHEMA)
+    conn.execute(
+        "INSERT INTO lint_rules"
+        " (id, grep_pattern, file_glob, message, is_blocking, source_skill, enforcement)"
+        " VALUES (?, ?, ?, ?, ?, ?, ?)",
+        (5, _PATTERN, "**/*.txt", "forbidden token present", is_blocking,
+         "retro", enforcement),
+    )
+    conn.commit()
+    conn.close()
+    return db_path
+
+
+def _make_tree_with_violation(tmp_path):
+    """Create a source tree with one file containing the flagged line."""
+    root = tmp_path / "tree"
+    root.mkdir()
+    (root / "offender.txt").write_text(_FLAGGED_LINE, encoding="utf-8")
+    return str(root)
+
+
+def _patch_db(monkeypatch, db_path):
+    """Force tusk-lint's DB resolver to point at our seeded tmp DB."""
+    monkeypatch.setattr(lint, "_db_path_from_root", lambda root: db_path)
+
+
+def _row(db_path, rule_id):
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    try:
+        return conn.execute(
+            "SELECT * FROM lint_rules WHERE id = ?", (rule_id,)
+        ).fetchone()
+    finally:
+        conn.close()
+
+
+def _promote(db_path, *args) -> int:
+    argv = ["tusk-lint-rules.py", db_path, "/dev/null", "promote", *args]
+    return rules_mod.main(argv)
+
+
+def _add(db_path, *args) -> int:
+    argv = ["tusk-lint-rules.py", db_path, "/dev/null", "add", *args]
+    return rules_mod.main(argv)
+
+
+class TestAdvisoryNoGate:
+    def test_advisory_no_gate_blocking_rule_excluded_from_gating_bucket(
+        self, tmp_path, monkeypatch
+    ):
+        """A blocking rule staged advisory must NOT load into the gating bucket
+        (Rule 16), so it cannot push the lint exit code non-zero."""
+        db = _make_db(tmp_path, is_blocking=1, enforcement="advisory")
+        _patch_db(monkeypatch, db)
+        tree = _make_tree_with_violation(tmp_path)
+
+        gating = lint._load_lint_rules(tree, gating=True)
+        assert gating == [], "advisory rule must not appear in the gating bucket"
+
+        # And running the gating rule against a tree that DOES violate it yields
+        # zero gating violations — the gate stays green.
+        assert lint.rule16_db_rules_blocking(tree) == []
+
+    def test_enforcing_blocking_rule_still_gates(self, tmp_path, monkeypatch):
+        """Control: a blocking + enforcing rule still gates (regression guard)."""
+        db = _make_db(tmp_path, is_blocking=1, enforcement="enforcing")
+        _patch_db(monkeypatch, db)
+        tree = _make_tree_with_violation(tmp_path)
+
+        gating = lint._load_lint_rules(tree, gating=True)
+        assert len(gating) == 1
+
+        violations = lint.rule16_db_rules_blocking(tree)
+        assert len(violations) == 1
+        assert "offender.txt" in violations[0]
+
+
+class TestAdvisoryWarns:
+    def test_advisory_warns_blocking_rule_reported_in_advisory_bucket(
+        self, tmp_path, monkeypatch
+    ):
+        """The advisory rule's hits must still be reported — they land in the
+        warn-only bucket (Rule 17) instead of the gating bucket."""
+        db = _make_db(tmp_path, is_blocking=1, enforcement="advisory")
+        _patch_db(monkeypatch, db)
+        tree = _make_tree_with_violation(tmp_path)
+
+        warn_rules = lint._load_lint_rules(tree, gating=False)
+        assert len(warn_rules) == 1, "advisory rule must appear in the warn bucket"
+
+        violations = lint.rule17_db_rules_advisory(tree)
+        assert len(violations) == 1
+        assert "offender.txt" in violations[0]
+        assert "forbidden token present" in violations[0]
+
+    def test_enforcing_rule_not_double_counted_in_advisory_bucket(
+        self, tmp_path, monkeypatch
+    ):
+        """A blocking + enforcing rule must NOT also appear in the warn bucket,
+        or its hits would be counted twice."""
+        db = _make_db(tmp_path, is_blocking=1, enforcement="enforcing")
+        _patch_db(monkeypatch, db)
+        tree = _make_tree_with_violation(tmp_path)
+
+        assert lint._load_lint_rules(tree, gating=False) == []
+        assert lint.rule17_db_rules_advisory(tree) == []
+
+    def test_non_blocking_rule_still_advisory(self, tmp_path, monkeypatch):
+        """Backwards compat: an is_blocking=0 rule remains warn-only regardless
+        of enforcement."""
+        db = _make_db(tmp_path, is_blocking=0, enforcement="enforcing")
+        _patch_db(monkeypatch, db)
+        tree = _make_tree_with_violation(tmp_path)
+
+        assert lint._load_lint_rules(tree, gating=True) == []
+        warn_rules = lint._load_lint_rules(tree, gating=False)
+        assert len(warn_rules) == 1
+
+
+class TestPromote:
+    def test_promote_flips_advisory_to_enforcing(self, tmp_path, capsys):
+        db = _make_db(tmp_path, is_blocking=1, enforcement="advisory")
+        assert _promote(db, "5") == 0
+        out = capsys.readouterr().out
+        assert "5" in out
+        assert "enforcing" in out
+        assert _row(db, 5)["enforcement"] == "enforcing"
+
+    def test_promote_after_add_advisory_round_trip(self, tmp_path):
+        """An `add --advisory` rule starts advisory and becomes enforcing on
+        promote (end-to-end through the public CLI surface)."""
+        db = str(tmp_path / "tasks.db")
+        conn = sqlite3.connect(db)
+        conn.executescript(_LINT_RULES_SCHEMA)
+        conn.commit()
+        conn.close()
+
+        assert _add(db, _PATTERN, "**/*.txt", "msg", "--blocking", "--advisory") == 0
+        new_id = _row_max_id(db)
+        assert _row(db, new_id)["enforcement"] == "advisory"
+        assert _row(db, new_id)["is_blocking"] == 1
+
+        assert _promote(db, str(new_id)) == 0
+        assert _row(db, new_id)["enforcement"] == "enforcing"
+
+    def test_promote_already_enforcing_is_noop(self, tmp_path, capsys):
+        db = _make_db(tmp_path, is_blocking=1, enforcement="enforcing")
+        assert _promote(db, "5") == 0
+        assert "already enforcing" in capsys.readouterr().out
+        assert _row(db, 5)["enforcement"] == "enforcing"
+
+    def test_promote_unknown_id_exits_2(self, tmp_path, capsys):
+        db = _make_db(tmp_path, is_blocking=1, enforcement="advisory")
+        assert _promote(db, "99999") == 2
+        err = capsys.readouterr().err
+        assert "99999" in err
+        assert "not found" in err
+
+    def test_add_default_enforcement_is_enforcing(self, tmp_path):
+        """Without --advisory, a rule is added enforcing (default behavior
+        unchanged)."""
+        db = str(tmp_path / "tasks.db")
+        conn = sqlite3.connect(db)
+        conn.executescript(_LINT_RULES_SCHEMA)
+        conn.commit()
+        conn.close()
+
+        assert _add(db, _PATTERN, "**/*.txt", "msg", "--blocking") == 0
+        new_id = _row_max_id(db)
+        assert _row(db, new_id)["enforcement"] == "enforcing"
+
+
+def _row_max_id(db_path) -> int:
+    conn = sqlite3.connect(db_path)
+    try:
+        return conn.execute("SELECT MAX(id) FROM lint_rules").fetchone()[0]
+    finally:
+        conn.close()


### PR DESCRIPTION
## Summary

Adds an orthogonal `enforcement` tier ('advisory' | 'enforcing', default 'enforcing') to the `lint_rules` table so a newly-discovered anti-pattern can be staged for observation before it gates merge. This is the foundation for auto-proposing lint rules from retro output.

A rule's hits gate the lint exit code (and therefore `tusk commit` / `tusk merge`) only when `is_blocking = 1 AND enforcement = 'enforcing'`. An advisory-enforcement rule warns but never gates, even when `is_blocking = 1`.

### Changes
- **Migration 82** (`bin/tusk-migrate.py`): `ALTER TABLE lint_rules ADD COLUMN enforcement TEXT NOT NULL DEFAULT 'enforcing' CHECK (enforcement IN ('advisory','enforcing'))`; registered in MIGRATIONS. No views project `lint_rules` columns, so none needed recreating.
- **`bin/tusk`** (cmd_init): mirrored the `enforcement` column + CHECK into the canonical `CREATE TABLE lint_rules`; bumped `PRAGMA user_version` 81 to 82.
- **`bin/tusk-lint-rules.py`**: `lint-rule add --advisory` stages a rule advisory-only; new `lint-rule promote <id>` flips advisory to enforcing (no-op if already enforcing, exit 2 if not found); `lint-rule list` surfaces the ENFORCE column.
- **`bin/tusk-lint.py`**: `_load_lint_rules` now partitions on `is_blocking = 1 AND enforcement = 'enforcing'` (gating) vs. everything else (warn-only). Rule 16 gates, Rule 17 warns. Degrades gracefully on a pre-migration DB (falls back to `is_blocking`-only).
- **`docs/DOMAIN.md`**: documented the `enforcement` column and the orthogonality with `is_blocking`.

## Test plan
- `tests/integration/test_lint_rule_advisory.py` (criterion 3322, `-k migration`): migration adds the column, default 'enforcing', CHECK rejects bad values, fresh init at v82, idempotent re-run.
- `tests/unit/test_lint_rule_advisory.py`: advisory_no_gate (blocking+advisory rule excluded from gating bucket), advisory_warns (same rule reported in warn bucket), promote (advisory to enforcing round-trip via `add --advisory` + `promote`, no-op-when-enforcing, unknown-id exit 2, default-enforcing).
- Full unit suite (2194) and all 213 migration-related integration tests pass; `tusk lint` clean (only the expected big-bang advisory).

Note: VERSION/CHANGELOG bump intentionally omitted — consolidated after the chain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
