### PR TITLE
[TASK-714] Wire drain-then-propose into /loop

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -224,7 +224,7 @@ Two external library repos ship their own `tusk-bootstrap.json` and are pre-conf
 - **`/resume-task`** — Recover session from branch name + progress log
 - **`/chain`** — Parallel dependency sub-DAG execution (one or more head IDs)
 - **`/objective`** — Run an objective end to end: create it, decompose into tasks via `/create-task`, drive the linked sub-DAG to Done in parallel waves via `/chain`, roll up via `tusk objective brief`, and close via `tusk objective done`
-- **`/loop`** — Autonomous backlog loop; dispatches `/chain` or `/tusk` until empty
+- **`/loop`** — Autonomous backlog loop; dispatches `/chain` or `/tusk` until the backlog drains, then surfaces `tusk propose-work` candidates (proposals only — never auto-created)
 - **`/review-commits`** — Parallel AI code review; fixes must_fix findings, and fixes, preserves as context, dismisses, or spins suggest findings into follow-up tasks
 - **`/address-issue`** — Fetch a GitHub issue, score it, create a tusk task, and work through it
 - **`/ios-libs-issue`** — File an issue against the configured iOS lib repo (`project_type=ios_app` only); auto-attaches originating tusk task

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -242,7 +242,7 @@ Two external library repos ship their own `tusk-bootstrap.json` and are pre-conf
 - **`/resume-task`** — Recover session from branch name + progress log
 - **`/chain`** — Parallel dependency sub-DAG execution (one or more head IDs)
 - **`/objective`** — Run an objective end to end: create it, decompose into tasks via `/create-task`, drive the linked sub-DAG to Done in parallel waves via `/chain`, roll up via `tusk objective brief`, and close via `tusk objective done`
-- **`/loop`** — Autonomous backlog loop; dispatches `/chain` or `/tusk` until empty
+- **`/loop`** — Autonomous backlog loop; dispatches `/chain` or `/tusk` until the backlog drains, then surfaces `tusk propose-work` candidates (proposals only — never auto-created)
 - **`/review-commits`** — Parallel AI code review; fixes must_fix findings, and fixes, preserves as context, dismisses, or spins suggest findings into follow-up tasks
 - **`/address-issue`** — Fetch a GitHub issue, score it, create a tusk task, and work through it
 - **`/ios-libs-issue`** — File an issue against the configured iOS lib repo (`project_type=ios_app` only); auto-attaches originating tusk task

--- a/bin/tusk-loop.py
+++ b/bin/tusk-loop.py
@@ -9,9 +9,12 @@ Arguments received from tusk:
     sys.argv[2] — config path (accepted for consistency, unused)
     sys.argv[3:] — optional flags
 
-Loop behavior:
+Loop behavior (drain-then-propose):
   1. Query highest-priority ready task (no incomplete dependencies, no open blockers)
-  2. If no task found: stop (empty backlog)
+  2. If no task found: run `tusk propose-work` and surface the ranked candidates
+     to the operator (node `propose_on_empty`), then stop. Proposals are
+     surfaced only — never auto-created — preserving the human gate on task
+     origination.
   3. Check if chain head via v_chain_heads view — task in view means it has downstream dependents
   4. If chain head → spawn claude -p /chain <id> [--on-failure <strategy>]
      Else        → spawn claude -p /tusk <id>
@@ -83,6 +86,58 @@ def is_chain_head(conn: sqlite3.Connection, task_id: int) -> bool:
         return False
 
 
+def decide_dispatch(task: dict | None, chain_head: bool) -> dict:
+    """Pure decision: given the next ready task (or None) and whether it is a chain
+    head, return the dispatch decision as a dict with a ``node`` field.
+
+    Nodes:
+      - ``propose_on_empty`` — no ready task; surface `tusk propose-work` candidates
+        to the operator instead of stopping silently. Proposals are surfaced only,
+        never auto-created — the human gate on task origination is preserved.
+      - ``chain``            — dispatch the chain head via /chain.
+      - ``tusk``             — dispatch the standalone task via /tusk.
+    """
+    if task is None:
+        return {"node": "propose_on_empty", "skill": None, "task_id": None}
+    if chain_head:
+        return {"node": "chain", "skill": "chain", "task_id": task["id"]}
+    return {"node": "tusk", "skill": "tusk", "task_id": task["id"]}
+
+
+def propose_work() -> int:
+    """Run `tusk propose-work` and stream its ranked candidates to the operator.
+
+    Surfaces origination candidates only — never inserts tasks. Returns the
+    process exit code (non-fatal: failures degrade to an empty surface).
+    """
+    result = subprocess.run(
+        ["tusk", "propose-work"],
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+    )
+    candidates = (result.stdout or "").strip()
+    if result.returncode == 0 and candidates and candidates != "[]":
+        print(
+            "Backlog drained — ranked work proposals (review and create via "
+            "/create-task; nothing is auto-created):",
+            flush=True,
+        )
+        print(candidates, flush=True)
+    elif result.returncode == 0:
+        print("Backlog drained — no work proposals surfaced.", flush=True)
+    else:
+        stderr = (result.stderr or "").strip()
+        print(
+            f"Backlog drained — `tusk propose-work` exited {result.returncode}"
+            + (f": {stderr}" if stderr else "")
+            + " — no proposals surfaced.",
+            file=sys.stderr,
+            flush=True,
+        )
+    return result.returncode
+
+
 def spawn_agent(skill: str, task_id: int, on_failure: str | None = None) -> int:
     """Spawn claude -p /<skill> <task_id> [--on-failure <strategy>]. Returns the process exit code."""
     prompt = f"/{skill} {task_id}"
@@ -148,15 +203,22 @@ Examples:
         while True:
             task = get_next_task(conn, exclude_ids=dispatched_ids if dispatched_ids else None)
 
-            if task is None:
-                print("Backlog empty — loop complete.", flush=True)
+            chain_head = is_chain_head(conn, task["id"]) if task is not None else False
+            decision = decide_dispatch(task, chain_head)
+
+            if decision["node"] == "propose_on_empty":
+                # Drain-then-propose: instead of stopping silently, surface ranked
+                # work proposals for the operator to act on. Nothing is auto-created.
+                print("Backlog empty — surfacing work proposals.", flush=True)
+                if not args.dry_run:
+                    propose_work()
+                else:
+                    print("[dry-run] Would run: tusk propose-work", flush=True)
                 break
 
             task_id = task["id"]
             summary = task["summary"]
-
-            chain_head = is_chain_head(conn, task_id)
-            skill = "chain" if chain_head else "tusk"
+            skill = decision["skill"]
 
             if args.dry_run:
                 on_failure_suffix = (

--- a/codex-prompts/loop.md
+++ b/codex-prompts/loop.md
@@ -4,6 +4,14 @@ Runs the autonomous backlog loop via the `tusk loop` CLI. Queries the
 highest-priority ready task, dispatches it to the chain or task workflow,
 and repeats until the backlog is empty or a stop condition is met.
 
+**Drain-then-propose:** when the backlog drains (no ready task remains),
+`tusk loop` does not stop silently — it runs `tusk propose-work` and surfaces
+the ranked origination candidates (unconfirmed skill patches, unconsumed
+next_steps, recurring jot categories, repo TODO/FIXME scan, cost outliers)
+for the operator to review. These proposals are **surfaced only — never
+auto-created**. Task origination stays behind the human gate: review the
+candidates and create the worthwhile ones via `/create-task`.
+
 > **Conventions:** Run `tusk conventions search <topic>` for project rules.
 > Do not restate convention text inline — it drifts from the DB.
 
@@ -42,8 +50,12 @@ tusk loop --on-failure abort
 3. Dispatches:
    - **Chain head** → follow `chain.md` for `<id>` (sequential wave loop).
    - **Standalone** → follow `tusk.md` for `<id>`.
-4. Stops on non-zero exit from any dispatch, on empty backlog, or when
-   `--max-tasks` is reached.
+4. On an **empty backlog** (no ready task), runs `tusk propose-work` and
+   surfaces the ranked candidates to the operator, then stops. Proposals are
+   surfaced only — nothing is auto-created; review and create the worthwhile
+   ones via `/create-task`.
+5. Also stops on non-zero exit from any dispatch or when `--max-tasks` is
+   reached.
 
 > **Note:** Tasks dispatched via `tusk.md` or `chain.md` use
 > `tusk task-start --force` so that zero-criteria tasks emit a warning

--- a/skills/loop/SKILL.md
+++ b/skills/loop/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: loop
-description: Autonomously work through the backlog — dispatches /chain for chain heads, /tusk for standalone tasks, repeating until empty
+description: Autonomously work through the backlog — dispatches /chain for chain heads, /tusk for standalone tasks, then surfaces tusk propose-work candidates once the backlog drains
 allowed-tools: Bash
 model: sonnet
 ---
@@ -8,6 +8,8 @@ model: sonnet
 # Loop
 
 Runs the autonomous backlog loop via the `tusk loop` CLI command. Queries the highest-priority ready task, dispatches it to `/chain` (if it has dependents) or `/tusk` (standalone), and repeats until the backlog is empty or a stop condition is met.
+
+**Drain-then-propose:** when the backlog drains (no ready task remains), `tusk loop` does not stop silently — it runs `tusk propose-work` and surfaces the ranked origination candidates (unconfirmed skill patches, unconsumed next_steps, recurring jot categories, repo TODO/FIXME scan, cost outliers) for the operator to review. These proposals are **surfaced only — never auto-created**. Task origination stays behind the human gate: review the candidates and create the ones worth doing via `/create-task`. The loop never inserts a task on its own.
 
 > Use `/create-task` for task creation — handles decomposition, deduplication, criteria, and deps. Use `tusk task-insert` only for bulk/automated inserts.
 
@@ -37,7 +39,8 @@ tusk loop --on-failure abort
 3. Dispatches:
    - **Chain head** → `claude -p /chain <id> [--on-failure <strategy>]`
    - **Standalone** → `claude -p /tusk <id>`
-4. Stops on non-zero exit from any agent, on empty backlog, or when `--max-tasks` is reached
+4. On an **empty backlog** (no ready task), runs `tusk propose-work` and surfaces the ranked candidates to the operator, then stops. Proposals are surfaced only — nothing is auto-created; review and create the worthwhile ones via `/create-task`.
+5. Also stops on non-zero exit from any agent or when `--max-tasks` is reached
 
 > **Note:** Tasks dispatched via `/tusk` or `/chain` use `tusk task-start --force` so that zero-criteria tasks emit a warning rather than hard-failing the automated workflow.
 

--- a/tests/unit/test_loop.py
+++ b/tests/unit/test_loop.py
@@ -1,0 +1,97 @@
+"""Unit tests for tusk-loop.py — drain-then-propose dispatch decision.
+
+Covers the dispatch-decision node IDs surfaced by `decide_dispatch`:
+- propose_on_empty — no ready task → surface `tusk propose-work` candidates,
+                     do NOT auto-create (TASK-714 criterion #3338 / #3336)
+- chain            — a ready chain head → /chain dispatch
+- tusk             — a ready standalone task → /tusk dispatch
+
+`decide_dispatch` is a pure function (no DB, no subprocess), so these tests
+exercise the branch logic directly. `propose_work` is exercised with a stubbed
+subprocess to confirm proposals are *surfaced* and never inserted.
+"""
+
+import importlib.util
+import os
+import sys
+from unittest import mock
+
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+BIN = os.path.join(REPO_ROOT, "bin")
+
+# tusk-loop.py does `sys.path.insert(0, dirname(__file__))` then `import tusk_loader`,
+# so the bin dir must be importable for the module load to succeed.
+if BIN not in sys.path:
+    sys.path.insert(0, BIN)
+
+_spec = importlib.util.spec_from_file_location(
+    "tusk_loop",
+    os.path.join(BIN, "tusk-loop.py"),
+)
+mod = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(mod)
+
+
+# --- decide_dispatch: the dispatch-on-empty decision -------------------------
+
+def test_propose_on_empty_when_no_ready_task():
+    """No ready task → node is propose_on_empty (not a stop, not a dispatch)."""
+    decision = mod.decide_dispatch(None, chain_head=False)
+    assert decision["node"] == "propose_on_empty"
+    # No skill is dispatched — the operator reviews proposals, nothing auto-runs.
+    assert decision["skill"] is None
+    assert decision["task_id"] is None
+
+
+def test_propose_on_empty_ignores_chain_head_flag():
+    """With no task, the chain_head flag is irrelevant — still propose_on_empty."""
+    decision = mod.decide_dispatch(None, chain_head=True)
+    assert decision["node"] == "propose_on_empty"
+
+
+def test_chain_head_dispatches_chain():
+    decision = mod.decide_dispatch({"id": 5}, chain_head=True)
+    assert decision["node"] == "chain"
+    assert decision["skill"] == "chain"
+    assert decision["task_id"] == 5
+
+
+def test_standalone_dispatches_tusk():
+    decision = mod.decide_dispatch({"id": 9}, chain_head=False)
+    assert decision["node"] == "tusk"
+    assert decision["skill"] == "tusk"
+    assert decision["task_id"] == 9
+
+
+# --- propose_work: surfaces, never auto-creates ------------------------------
+
+def test_propose_on_empty_surfaces_candidates_without_creating(capsys):
+    """propose_work runs `tusk propose-work` (read-only) and prints the ranked
+    candidates. It must never invoke a task-inserting command — the human gate
+    on task origination is preserved (criterion #3336)."""
+    fake = mock.Mock(returncode=0, stdout='[{"source":"todo_scan","score":45.0}]', stderr="")
+    with mock.patch.object(mod.subprocess, "run", return_value=fake) as run:
+        rc = mod.propose_work()
+
+    assert rc == 0
+    # Exactly one subprocess call, and it is the read-only propose-work command.
+    run.assert_called_once()
+    argv = run.call_args.args[0]
+    assert argv[:2] == ["tusk", "propose-work"]
+    # No task-creating verbs are ever issued.
+    assert not any(verb in argv for verb in ("task-insert", "task-update", "create-task"))
+
+    out = capsys.readouterr().out
+    assert "todo_scan" in out
+    # Wording makes the human gate explicit.
+    assert "/create-task" in out
+
+
+def test_propose_on_empty_handles_empty_proposals(capsys):
+    """An empty proposal array is surfaced as a clean message, not an error."""
+    fake = mock.Mock(returncode=0, stdout="[]", stderr="")
+    with mock.patch.object(mod.subprocess, "run", return_value=fake):
+        rc = mod.propose_work()
+    assert rc == 0
+    assert "no work proposals" in capsys.readouterr().out.lower()


### PR DESCRIPTION
## Summary
Turns /loop from drain-until-empty into drain-then-propose: when `tusk deps ready` is empty, /loop runs read-only `tusk propose-work` and surfaces ranked candidates to the operator instead of stopping. Proposals are surfaced only, never auto-created (human gate preserved).

## Test plan
- tests/unit/test_loop.py (decide_dispatch propose_on_empty; propose_work issues only read-only command)
- 17 tests pass; tusk lint clean

Part of OBJ-1 (self-improving loop). VERSION/CHANGELOG consolidated at chain end.