### PR TITLE
[TASK-712] Add tusk lint-rule propose + wire /retro

### DIFF
--- a/bin/tusk
+++ b/bin/tusk
@@ -1174,6 +1174,7 @@ CREATE TABLE lint_rules (
     is_blocking INTEGER NOT NULL DEFAULT 0,
     source_skill TEXT,
     enforcement TEXT NOT NULL DEFAULT 'enforcing',
+    source_finding_id INTEGER,
     created_at TEXT DEFAULT (datetime('now')),
     CHECK (is_blocking IN (0, 1)),
     CHECK (enforcement IN ('advisory', 'enforcing'))
@@ -1273,7 +1274,7 @@ PRECHECK_VERDICTS_SCHEMA
   fi
 
   # Set schema version so fresh DBs never need migration
-  sqlite3 "$DB_PATH" "PRAGMA user_version = 82;"
+  sqlite3 "$DB_PATH" "PRAGMA user_version = 83;"
 
   echo "Initialized task database at $DB_PATH"
   echo "Note: tusk/tasks.db is local-only — not synced across machines."

--- a/bin/tusk-lint-rules.py
+++ b/bin/tusk-lint-rules.py
@@ -4,6 +4,8 @@
 Called by the tusk wrapper:
     tusk lint-rule add <pattern> <file_glob> <message> [--blocking] [--advisory]
                        [--skill <name>]
+    tusk lint-rule propose <pattern> <file_glob> <message>
+                           [--finding-id <id>] [--skill <name>]
     tusk lint-rule list
     tusk lint-rule update <id> [--file-glob <glob>] [--grep-pattern <pattern>]
                                [--message <text>] [--blocking | --no-blocking]
@@ -41,6 +43,44 @@ def cmd_add(args: argparse.Namespace, db_path: str) -> int:
              1 if args.blocking else 0,
              args.skill,
              enforcement),
+        )
+        conn.commit()
+        print(cur.lastrowid)
+        return 0
+    finally:
+        conn.close()
+
+
+def cmd_propose(args: argparse.Namespace, db_path: str) -> int:
+    """Stage a grep-detectable anti-pattern surfaced by /retro as an advisory rule.
+
+    Always inserts ``enforcement='advisory'`` and ``is_blocking=1`` so the rule
+    warns on hits but never gates ``tusk lint``/``commit``/``merge`` until
+    ``tusk lint-rule promote`` flips it to enforcing once the pattern is observed
+    to hold. The originating retro finding is recorded in ``source_finding_id``
+    for provenance back to the retrospective that proposed the rule. When
+    ``--finding-id`` is supplied it is validated as a real retro_findings FK
+    before the insert so a typo'd id fails fast.
+    """
+    conn = get_connection(db_path)
+    try:
+        if args.finding_id is not None:
+            finding = conn.execute(
+                "SELECT id FROM retro_findings WHERE id = ?", (args.finding_id,)
+            ).fetchone()
+            if not finding:
+                print(
+                    f"Error: retro finding {args.finding_id} not found",
+                    file=sys.stderr,
+                )
+                return 2
+        cur = conn.execute(
+            "INSERT INTO lint_rules"
+            " (grep_pattern, file_glob, message, is_blocking, source_skill,"
+            "  enforcement, source_finding_id)"
+            " VALUES (?, ?, ?, 1, ?, 'advisory', ?)",
+            (args.pattern, args.file_glob, args.message,
+             args.skill, args.finding_id),
         )
         conn.commit()
         print(cur.lastrowid)
@@ -167,7 +207,7 @@ def cmd_promote(args: argparse.Namespace, db_path: str) -> int:
 
 def main(argv: list[str]) -> int:
     if len(argv) < 3:
-        print("Usage: tusk lint-rule {add|list|update|promote|remove} ...", file=sys.stderr)
+        print("Usage: tusk lint-rule {add|propose|list|update|promote|remove} ...", file=sys.stderr)
         return 2
 
     db_path = argv[1]
@@ -192,6 +232,23 @@ def main(argv: list[str]) -> int:
                             help="skill that created this rule")
         args = parser.parse_args(argv[4:])
         return cmd_add(args, db_path)
+
+    elif subcommand == "propose":
+        parser = argparse.ArgumentParser(allow_abbrev=False, prog="tusk lint-rule propose")
+        parser.add_argument("pattern", help="grep pattern to search for")
+        parser.add_argument("file_glob",
+                            help="file glob to search (e.g. '**/*.py'). Pass a comma-separated"
+                                 " list to scope multiple paths"
+                                 " (e.g. 'skills/**/*.md,codex-prompts/**/*.md').")
+        parser.add_argument("message", help="violation message to display")
+        parser.add_argument("--finding-id", dest="finding_id", type=int, default=None,
+                            metavar="ID",
+                            help="retro_findings id this rule was proposed from "
+                                 "(recorded as provenance)")
+        parser.add_argument("--skill", default="retro", metavar="NAME",
+                            help="skill that proposed this rule (default: retro)")
+        args = parser.parse_args(argv[4:])
+        return cmd_propose(args, db_path)
 
     elif subcommand == "list":
         return cmd_list(db_path)
@@ -232,13 +289,13 @@ def main(argv: list[str]) -> int:
 
     else:
         print(f"Unknown subcommand: {subcommand!r}", file=sys.stderr)
-        print("Usage: tusk lint-rule {add|list|update|promote|remove} ...", file=sys.stderr)
+        print("Usage: tusk lint-rule {add|propose|list|update|promote|remove} ...", file=sys.stderr)
         return 2
 
 
 if __name__ == "__main__":
     if len(sys.argv) < 2 or not sys.argv[1].endswith(".db"):
         print("Error: This script must be invoked via the tusk wrapper.", file=sys.stderr)
-        print("Use: tusk lint-rule {add|list|update|remove} ...", file=sys.stderr)
+        print("Use: tusk lint-rule {add|propose|list|update|remove} ...", file=sys.stderr)
         sys.exit(1)
     sys.exit(main(sys.argv))

--- a/bin/tusk-migrate.py
+++ b/bin/tusk-migrate.py
@@ -3543,6 +3543,35 @@ def migrate_82(db_path: str, config_path: str, script_dir: str) -> None:
     _progress("  Migration 82: added lint_rules.enforcement")
 
 
+def migrate_83(db_path: str, config_path: str, script_dir: str) -> None:
+    """Add lint_rules.source_finding_id for retro-finding provenance.
+
+    Task 712: `tusk lint-rule propose` converts a grep-detectable anti-pattern
+    surfaced by /retro into a staged advisory rule and records which retro
+    finding it came from. The `source_finding_id` column carries that
+    provenance — a nullable reference into retro_findings(id). It is added
+    without an inline FK constraint because ALTER TABLE ADD COLUMN cannot
+    declare one against an existing table; the value is set on insert by
+    `lint-rule propose` and left NULL for rules added any other way. No views
+    project lint_rules columns, so none need recreating.
+
+    Idempotent: guarded with has_column; re-running is a no-op after the column
+    exists.
+    """
+    if get_version(db_path) >= 83:
+        _progress("  Migration 83: added lint_rules.source_finding_id")
+        return
+
+    if not has_column(db_path, "lint_rules", "source_finding_id"):
+        run_script(
+            db_path,
+            "ALTER TABLE lint_rules ADD COLUMN source_finding_id INTEGER;",
+        )
+
+    set_version(db_path, 83)
+    _progress("  Migration 83: added lint_rules.source_finding_id")
+
+
 # ── Migration registry ────────────────────────────────────────────────────────
 
 MIGRATIONS = [
@@ -3628,6 +3657,7 @@ MIGRATIONS = [
     (80, migrate_80),
     (81, migrate_81),
     (82, migrate_82),
+    (83, migrate_83),
 ]
 
 

--- a/codex-prompts/retro.md
+++ b/codex-prompts/retro.md
@@ -309,11 +309,15 @@ For each approved project-issue finding routed here:
 
 ### LR-2b: Apply Lint Rules Inline (only if lint-rule action candidates exist)
 
-For each lint-rule action candidate:
+For each grep-detectable anti-pattern you surfaced, **emit a `tusk
+lint-rule propose` call** rather than `tusk lint-rule add`. `propose`
+stages the rule **advisory** (warns but never gates `tusk
+lint`/`commit`/`merge` until `tusk lint-rule promote <id>`) and records
+provenance back to the originating retro finding via `--finding-id`.
 
 1. Present the proposed rule and command:
    ```bash
-   tusk lint-rule add '<pattern>' '<file_glob>' '<message>'
+   tusk lint-rule propose '<pattern>' '<file_glob>' '<message>' [--finding-id <finding_id>]
    ```
    Ask for approval. The bar is high — only proceed if you observed an
    actual mistake that a grep rule would have caught.
@@ -325,9 +329,9 @@ For each lint-rule action candidate:
 3. **If declined or fallback**:
    ```bash
    tusk task-insert "Add lint rule: <short description>" \
-     "Run: tusk lint-rule add '<pattern>' '<file_glob>' '<message>'" \
+     "Run: tusk lint-rule propose '<pattern>' '<file_glob>' '<message>'" \
      --priority "Low" --task-type "<task_type>" --complexity "XS" \
-     --criteria "tusk lint-rule add has been run with the specified pattern, glob, and message"
+     --criteria "tusk lint-rule propose has been run with the specified pattern, glob, and message"
    ```
 
 ### LR-3: Report
@@ -386,7 +390,7 @@ tusk retro-finding add \
 - `context:<id>` — context atom added, resolved, or superseded via
   `tusk context`
 - `issue:<url>` — GitHub issue filed via `tusk report-issue`
-- `lint:<id>` — lint rule added via `tusk lint-rule add`
+- `lint:<id>` — lint rule staged via `tusk lint-rule propose` (advisory) or added via `tusk lint-rule add`
 - `convention:<id>` — convention added via `tusk conventions add`
 - `prompt-patch:<file>` — inline edit applied to a prompt file or
   agent doc

--- a/docs/DOMAIN.md
+++ b/docs/DOMAIN.md
@@ -614,9 +614,11 @@ A generalizable heuristic or rule captured for the project. Managed via `tusk co
 
 ### Lint Rule
 
-A DB-backed grep rule that `tusk lint` runs alongside its hardcoded rules. Rules are managed via `tusk lint-rule add/list/update/promote/remove` and created by skills or users. A rule's hits gate the lint exit code (and therefore `tusk commit`/`tusk merge`) only when `is_blocking = 1 AND enforcement = 'enforcing'`; everything else emits `WARN [ADVISORY]` and does not contribute to the non-zero exit code.
+A DB-backed grep rule that `tusk lint` runs alongside its hardcoded rules. Rules are managed via `tusk lint-rule add/propose/list/update/promote/remove` and created by skills or users. A rule's hits gate the lint exit code (and therefore `tusk commit`/`tusk merge`) only when `is_blocking = 1 AND enforcement = 'enforcing'`; everything else emits `WARN [ADVISORY]` and does not contribute to the non-zero exit code.
 
 `is_blocking` and `enforcement` are **orthogonal**: `is_blocking` is the long-standing distinction between Rule 16 (gating) and Rule 17 (advisory) candidates, while `enforcement` lets a newly-discovered anti-pattern be staged for observation — added with `tusk lint-rule add --advisory`, a rule warns but never gates even if `is_blocking=1`, until `tusk lint-rule promote <id>` flips it to `enforcing` once it has been observed to hold. This is the foundation for auto-proposing rules from retro output (Task 711).
+
+`tusk lint-rule propose <pattern> <file_glob> <message> [--finding-id <id>]` (Task 712) is the auto-propose entry point /retro emits for each grep-detectable anti-pattern it surfaces. It always inserts `is_blocking=1, enforcement='advisory'` (so a proposed rule warns but never gates until promoted) and records the originating retro finding in `source_finding_id` for provenance. A supplied `--finding-id` is validated as a real `retro_findings` FK before insert.
 
 | Attribute | Type | Constraints | Description |
 |-----------|------|-------------|-------------|
@@ -627,6 +629,7 @@ A DB-backed grep rule that `tusk lint` runs alongside its hardcoded rules. Rules
 | `is_blocking` | INTEGER | CHECK IN (0, 1); NOT NULL, default 0 | 1 = candidate to count toward lint exit code; 0 = advisory warning only |
 | `source_skill` | TEXT | nullable | Skill that created this rule (e.g. `lint-conventions`) |
 | `enforcement` | TEXT | CHECK IN ('advisory', 'enforcing'); NOT NULL, default 'enforcing' | `'enforcing'` = a blocking rule's hits gate the exit code; `'advisory'` = staged for observation, hits warn but never gate even when `is_blocking=1`. Flip via `tusk lint-rule promote`. |
+| `source_finding_id` | INTEGER | nullable | Provenance: the `retro_findings.id` a rule was proposed from via `tusk lint-rule propose`. NULL for rules added any other way. |
 | `created_at` | TEXT | default now | When the rule was added |
 
 ---

--- a/docs/SCRIPTS.md
+++ b/docs/SCRIPTS.md
@@ -96,7 +96,7 @@ require it).
 | **tusk-migrate.py** | `tusk migrate` | `tasks.db` (`PRAGMA user_version`) | DB schema (applies pending migrations in order) |
 | **tusk-setup.py** | `tusk setup` | `tasks.db`, `config.json` | nothing; returns config + backlog JSON in one call |
 | **tusk-lint.py** | `tusk lint` | repo files, `tasks.db`, config, `MANIFEST` | nothing; advisory output only; depends on `tusk-db-lib.py` |
-| **tusk-lint-rules.py** | `tusk lint-rule add\|list\|remove [flags]` | `lint_rules` | `lint_rules` |
+| **tusk-lint-rules.py** | `tusk lint-rule add\|propose\|list\|update\|promote\|remove [flags]` | `lint_rules`, `retro_findings` | `lint_rules` |
 | **tusk-test-detect.py** | `tusk test-detect` | `package.json`, lockfiles, `pyproject.toml`, `pytest.ini`, `Makefile`, etc. | nothing; returns `{"command": "…", "confidence": "…"}` |
 
 ### Sessions & Cost Tracking

--- a/skills/retro/FULL-RETRO.md
+++ b/skills/retro/FULL-RETRO.md
@@ -376,17 +376,17 @@ Apply this step if any approved finding has a proposed "add lint rule" action. W
 
 The bar is high — only proceed if you observed an **actual mistake** that a grep rule would have caught. Do not apply lint rules for general advice.
 
-For each lint-rule action candidate, attempt **inline application** first:
+For each grep-detectable anti-pattern you surfaced, **emit a `tusk lint-rule propose` call** rather than instructing the operator to run `tusk lint-rule add` by hand. `propose` stages the rule **advisory** — its hits warn but never gate `tusk lint`/`commit`/`merge` until someone runs `tusk lint-rule promote <id>` once the pattern is observed to hold — and records provenance back to the originating retro finding via `--finding-id`. This keeps a newly-proposed rule from blocking work before it has been validated.
 
 1. **Present the proposed rule** — show the exact command and ask for approval:
 
    > Found lint rule candidate: [finding description]
-   > Command: `tusk lint-rule add '<pattern>' '<file_glob>' '<message>'`
-   > Apply this rule now? (Reversible with `tusk lint-rule remove <id>`.)
+   > Command: `tusk lint-rule propose '<pattern>' '<file_glob>' '<message>'`
+   > Stage this advisory rule now? (Reversible with `tusk lint-rule remove <id>`; promote later with `tusk lint-rule promote <id>`.)
 
-2. **If the user approves** — run the command immediately:
+2. **If the user approves** — run the command immediately. If you have already recorded the originating finding, pass its id so the proposed rule carries provenance:
    ```bash
-   tusk lint-rule add '<pattern>' '<file_glob>' '<message>'
+   tusk lint-rule propose '<pattern>' '<file_glob>' '<message>' [--finding-id <finding_id>]
    ```
    - **Success**: note the rule ID returned. **Do not create a task** for this finding.
    - **Error or unavailable**: fall back to task creation (step 3).
@@ -394,9 +394,9 @@ For each lint-rule action candidate, attempt **inline application** first:
 3. **If the user declines**, or **if inline application fails**, create a task as a fallback:
    ```bash
    tusk task-insert "Add lint rule: <short description>" \
-     "Run: tusk lint-rule add '<pattern>' '<file_glob>' '<message>'" \
+     "Run: tusk lint-rule propose '<pattern>' '<file_glob>' '<message>'" \
      --priority "Low" --task-type "<task_type>" --complexity "XS" \
-     --criteria "tusk lint-rule add has been run with the specified pattern, glob, and message"
+     --criteria "tusk lint-rule propose has been run with the specified pattern, glob, and message"
    ```
 
 For `<task_type>`: use the project's config `task_types` array (already fetched via `tusk setup` in Step 0). Pick the entry that best fits a maintenance/tooling task (e.g., `maintenance`, `chore`, `tech-debt`, `infra` — whatever is closest in your project's list). If no entry is a clear fit, omit `--task-type` entirely.
@@ -527,7 +527,7 @@ tusk retro-finding add \
 - `criterion:<id>` — an acceptance criterion was added via `tusk criteria add`
 - `context:<id>` — a context atom was added, resolved, or superseded via `tusk context`
 - `issue:<url>` — a GitHub issue was filed via `tusk report-issue`
-- `lint:<id>` — a lint rule was added via `tusk lint-rule add`
+- `lint:<id>` — a lint rule was staged via `tusk lint-rule propose` (advisory) or added via `tusk lint-rule add`
 - `convention:<id>` — a convention was added via `tusk conventions add`
 - `skill-patch:<file>` — an inline edit was applied to a skill or agent doc
 - `doc-patch:<file>` — an inline edit was applied to README.md or a file under docs/

--- a/skills/retro/SKILL.md
+++ b/skills/retro/SKILL.md
@@ -273,27 +273,27 @@ Apply this step if any approved finding has a proposed "add lint rule" action. W
 
 The bar is high — only proceed if you observed an **actual mistake** that a grep rule would have caught. Do not apply lint rules for general advice.
 
-For each lint-rule action candidate, attempt **inline application** first:
+For each grep-detectable anti-pattern you surfaced, **emit a `tusk lint-rule propose` call** rather than instructing the operator to run `tusk lint-rule add` by hand. `propose` stages the rule **advisory** — its hits warn but never gate `tusk lint`/`commit`/`merge` until someone runs `tusk lint-rule promote <id>` once the pattern is observed to hold — and records provenance back to the originating retro finding via `--finding-id`. This keeps a newly-proposed rule from blocking work before it has been validated.
 
 1. **Present the proposed rule** — show the exact command and ask for approval:
 
    > Found lint rule candidate: [finding description]
-   > Command: `tusk lint-rule add '<pattern>' '<file_glob>' '<message>'`
-   > Apply this rule now? (Reversible with `tusk lint-rule remove <id>`.)
+   > Command: `tusk lint-rule propose '<pattern>' '<file_glob>' '<message>'`
+   > Stage this advisory rule now? (Reversible with `tusk lint-rule remove <id>`; promote later with `tusk lint-rule promote <id>`.)
 
-2. **If the user approves** — run the command immediately:
+2. **If the user approves** — run the command immediately. If you have already recorded the originating finding in LR-3a, pass its id so the proposed rule carries provenance:
    ```bash
-   tusk lint-rule add '<pattern>' '<file_glob>' '<message>'
+   tusk lint-rule propose '<pattern>' '<file_glob>' '<message>' [--finding-id <finding_id>]
    ```
-   - **Success**: note the rule ID returned. **Do not create a task** for this finding.
+   - **Success**: note the rule ID returned. **Do not create a task** for this finding. Record the action as `lint:<id>` in LR-3a.
    - **Error or unavailable**: fall back to task creation (step 3).
 
 3. **If the user declines**, or **if inline application fails**, create a task as a fallback:
    ```bash
    tusk task-insert "Add lint rule: <short description>" \
-     "Run: tusk lint-rule add '<pattern>' '<file_glob>' '<message>'" \
+     "Run: tusk lint-rule propose '<pattern>' '<file_glob>' '<message>'" \
      --priority "Low" --task-type "<task_type>" --complexity "XS" \
-     --criteria "tusk lint-rule add has been run with the specified pattern, glob, and message"
+     --criteria "tusk lint-rule propose has been run with the specified pattern, glob, and message"
    ```
 
 For `<task_type>`: use the project's config `task_types` array (already fetched via `tusk setup` in Step 0). Pick the entry that best fits a maintenance/tooling task (e.g., `maintenance`, `chore`, `tech-debt`, `infra` — whatever is closest in your project's list). If no entry is a clear fit, omit `--task-type` entirely.
@@ -342,7 +342,7 @@ tusk retro-finding add \
 - `criterion:<id>` — an acceptance criterion was added via `tusk criteria add`
 - `context:<id>` — a context atom was added, resolved, or superseded via `tusk context`
 - `issue:<url>` — a GitHub issue was filed via `tusk report-issue`
-- `lint:<id>` — a lint rule was added via `tusk lint-rule add`
+- `lint:<id>` — a lint rule was staged via `tusk lint-rule propose` (advisory) or added via `tusk lint-rule add`
 - `convention:<id>` — a convention was added via `tusk conventions add`
 - `skill-patch:<file>` — an inline edit was applied to a skill or agent doc
 - `doc-patch:<file>` — an inline edit was applied to README.md or a file under docs/

--- a/tests/unit/test_lint_rule_propose.py
+++ b/tests/unit/test_lint_rule_propose.py
@@ -1,0 +1,205 @@
+"""Unit tests for `tusk lint-rule propose` (Task 712).
+
+`tusk lint-rule propose` converts a grep-detectable anti-pattern surfaced by
+/retro into a *staged advisory* lint rule and records which retro finding it
+came from. It is the auto-propose path built on top of the advisory tier added
+in Task 711 (`enforcement='advisory'`).
+
+Three invariants, one per acceptance criterion:
+
+* ``stages_advisory`` (#3326) — a proposed rule is inserted
+  ``enforcement='advisory'`` (and ``is_blocking=1``), reusing the advisory
+  staging path so it warns but is never gating-by-default.
+* ``provenance`` (#3327) — the originating retro finding id is recorded in
+  ``lint_rules.source_finding_id``, and a bad finding id is rejected.
+* ``no_gate`` (#3328) — because it is advisory, a proposed rule does NOT load
+  into the gating bucket (Rule 16), so it cannot fail the lint gate that backs
+  ``tusk merge``.
+"""
+
+import importlib.util
+import os
+import sqlite3
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+BIN = os.path.join(REPO_ROOT, "bin")
+
+_lint_spec = importlib.util.spec_from_file_location(
+    "tusk_lint", os.path.join(BIN, "tusk-lint.py")
+)
+lint = importlib.util.module_from_spec(_lint_spec)
+_lint_spec.loader.exec_module(lint)
+
+_rules_spec = importlib.util.spec_from_file_location(
+    "tusk_lint_rules", os.path.join(BIN, "tusk-lint-rules.py")
+)
+rules_mod = importlib.util.module_from_spec(_rules_spec)
+_rules_spec.loader.exec_module(rules_mod)
+
+
+# Mirror the post-migration lint_rules schema (bin/tusk cmd_init + migrations
+# 82 and 83). source_finding_id carries provenance back to retro_findings.
+_LINT_RULES_SCHEMA = """
+CREATE TABLE lint_rules (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    grep_pattern TEXT NOT NULL,
+    file_glob TEXT NOT NULL,
+    message TEXT NOT NULL,
+    is_blocking INTEGER NOT NULL DEFAULT 0,
+    source_skill TEXT,
+    enforcement TEXT NOT NULL DEFAULT 'enforcing',
+    source_finding_id INTEGER,
+    created_at TEXT DEFAULT (datetime('now')),
+    CHECK (is_blocking IN (0, 1)),
+    CHECK (enforcement IN ('advisory', 'enforcing'))
+);
+"""
+
+# A minimal retro_findings table so --finding-id can be validated as a real FK.
+_RETRO_FINDINGS_SCHEMA = """
+CREATE TABLE retro_findings (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    skill_run_id INTEGER NOT NULL,
+    task_id INTEGER,
+    category TEXT NOT NULL,
+    summary TEXT NOT NULL,
+    action_taken TEXT,
+    created_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+"""
+
+# A pattern that matches a sentinel line we plant in a tmp file.
+_PATTERN = "FORBIDDEN_TOKEN"
+_FLAGGED_LINE = "x = FORBIDDEN_TOKEN  # planted\n"
+
+
+def _make_db(tmp_path, *, with_finding=False) -> str:
+    """Create a tmp DB with the lint_rules + retro_findings tables.
+
+    When ``with_finding`` is set, seed one retro_findings row (id 7) so a
+    propose call can reference it.
+    """
+    db_path = str(tmp_path / "tasks.db")
+    conn = sqlite3.connect(db_path)
+    conn.executescript(_LINT_RULES_SCHEMA)
+    conn.executescript(_RETRO_FINDINGS_SCHEMA)
+    if with_finding:
+        conn.execute(
+            "INSERT INTO retro_findings (id, skill_run_id, category, summary)"
+            " VALUES (7, 100, 'process', 'observed anti-pattern X')"
+        )
+    conn.commit()
+    conn.close()
+    return db_path
+
+
+def _make_tree_with_violation(tmp_path):
+    root = tmp_path / "tree"
+    root.mkdir()
+    (root / "offender.txt").write_text(_FLAGGED_LINE, encoding="utf-8")
+    return str(root)
+
+
+def _patch_db(monkeypatch, db_path):
+    monkeypatch.setattr(lint, "_db_path_from_root", lambda root: db_path)
+
+
+def _row(db_path, rule_id):
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    try:
+        return conn.execute(
+            "SELECT * FROM lint_rules WHERE id = ?", (rule_id,)
+        ).fetchone()
+    finally:
+        conn.close()
+
+
+def _max_id(db_path) -> int:
+    conn = sqlite3.connect(db_path)
+    try:
+        return conn.execute("SELECT MAX(id) FROM lint_rules").fetchone()[0]
+    finally:
+        conn.close()
+
+
+def _propose(db_path, *args) -> int:
+    argv = ["tusk-lint-rules.py", db_path, "/dev/null", "propose", *args]
+    return rules_mod.main(argv)
+
+
+class TestStagesAdvisory:
+    def test_propose_stages_advisory_rule(self, tmp_path, capsys):
+        """A proposed rule is inserted enforcement='advisory' and is_blocking=1."""
+        db = _make_db(tmp_path)
+        assert _propose(db, _PATTERN, "**/*.txt", "no forbidden token") == 0
+        new_id = _max_id(db)
+        # The lastrowid is echoed for the caller to capture.
+        assert str(new_id) in capsys.readouterr().out
+
+        row = _row(db, new_id)
+        assert row["enforcement"] == "advisory"
+        assert row["is_blocking"] == 1
+        assert row["grep_pattern"] == _PATTERN
+        assert row["file_glob"] == "**/*.txt"
+        assert row["message"] == "no forbidden token"
+
+    def test_propose_defaults_source_skill_to_retro(self, tmp_path):
+        db = _make_db(tmp_path)
+        assert _propose(db, _PATTERN, "**/*.txt", "msg") == 0
+        assert _row(db, _max_id(db))["source_skill"] == "retro"
+
+
+class TestProvenance:
+    def test_propose_records_source_finding_provenance(self, tmp_path):
+        """--finding-id is stored in source_finding_id for provenance back to
+        the originating retro finding."""
+        db = _make_db(tmp_path, with_finding=True)
+        assert _propose(db, _PATTERN, "**/*.txt", "msg", "--finding-id", "7") == 0
+        row = _row(db, _max_id(db))
+        assert row["source_finding_id"] == 7
+
+    def test_propose_without_finding_id_leaves_provenance_null(self, tmp_path):
+        db = _make_db(tmp_path)
+        assert _propose(db, _PATTERN, "**/*.txt", "msg") == 0
+        assert _row(db, _max_id(db))["source_finding_id"] is None
+
+    def test_propose_unknown_finding_id_rejected(self, tmp_path, capsys):
+        """A finding id that does not exist fails fast (exit 2) and inserts
+        nothing — provenance must reference a real finding."""
+        db = _make_db(tmp_path, with_finding=True)
+        assert _propose(db, _PATTERN, "**/*.txt", "msg", "--finding-id", "999") == 2
+        err = capsys.readouterr().err
+        assert "999" in err
+        assert "not found" in err
+        assert _max_id(db) is None  # nothing inserted
+
+
+class TestNoGate:
+    def test_proposed_rule_no_gate(self, tmp_path, monkeypatch):
+        """Because it is advisory, a proposed rule must NOT load into the gating
+        bucket (Rule 16) — so it cannot fail the lint gate that backs tusk
+        merge, even though it is is_blocking=1."""
+        db = _make_db(tmp_path)
+        assert _propose(db, _PATTERN, "**/*.txt", "no forbidden token") == 0
+        _patch_db(monkeypatch, db)
+        tree = _make_tree_with_violation(tmp_path)
+
+        gating = lint._load_lint_rules(tree, gating=True)
+        assert gating == [], "proposed advisory rule must not be in the gating bucket"
+        assert lint.rule16_db_rules_blocking(tree) == []
+
+    def test_proposed_rule_still_warns(self, tmp_path, monkeypatch):
+        """Control: the proposed rule still surfaces as an advisory warning
+        (Rule 17), so it is observable before promotion."""
+        db = _make_db(tmp_path)
+        assert _propose(db, _PATTERN, "**/*.txt", "no forbidden token") == 0
+        _patch_db(monkeypatch, db)
+        tree = _make_tree_with_violation(tmp_path)
+
+        warn_rules = lint._load_lint_rules(tree, gating=False)
+        assert len(warn_rules) == 1
+        violations = lint.rule17_db_rules_advisory(tree)
+        assert len(violations) == 1
+        assert "offender.txt" in violations[0]
+        assert "no forbidden token" in violations[0]


### PR DESCRIPTION
## Summary
Adds `tusk lint-rule propose` which stages a grep-detectable anti-pattern as an *advisory* lint rule (reusing the 711 advisory tier, so it warns but never gates until `tusk lint-rule promote`), recording the originating retro finding via a new `lint_rules.source_finding_id` column (migration 83). /retro now emits a `lint-rule propose` call instead of telling the operator to run `lint-rule add` by hand — closing the most-named Self-Improving gap in PILLARS.md.

## Test plan
- tests/unit/test_lint_rule_propose.py (stages_advisory, provenance, no_gate) — 7 pass
- migration 83 idempotent; full unit suite green

Part of OBJ-1 (self-improving loop). VERSION/CHANGELOG consolidated at chain end.