### PR TITLE
[TASK-770] Add task-import JSON parsing and dry-run validation

### DIFF
--- a/.claude/tusk-manifest.json
+++ b/.claude/tusk-manifest.json
@@ -88,6 +88,7 @@
   ".claude/bin/tusk-task-done.py",
   ".claude/bin/tusk-task-get-multi.py",
   ".claude/bin/tusk-task-get.py",
+  ".claude/bin/tusk-task-import.py",
   ".claude/bin/tusk-task-insert.py",
   ".claude/bin/tusk-task-list.py",
   ".claude/bin/tusk-task-reopen.py",

--- a/MANIFEST
+++ b/MANIFEST
@@ -88,6 +88,7 @@
   ".claude/bin/tusk-task-done.py",
   ".claude/bin/tusk-task-get-multi.py",
   ".claude/bin/tusk-task-get.py",
+  ".claude/bin/tusk-task-import.py",
   ".claude/bin/tusk-task-insert.py",
   ".claude/bin/tusk-task-list.py",
   ".claude/bin/tusk-task-reopen.py",

--- a/bin/tusk
+++ b/bin/tusk
@@ -1369,7 +1369,7 @@ candidates = [
   'review','review-verdict','review-pass-status','review-final-summary','review-diff-range','review-wait','review-check-perms','review-agent-cost',
   'deps','session-stats','session-recalc','session-close','skill-run','jot','jots','call-breakdown',
   'active-project','git-default-branch','branch-parse',
-  'task-get','task-get-multi','task-select','task-start','task-done','task-insert','task-update','task-reopen','task-unstart','task-list','task-summary','task-brief','task-worktree',
+  'task-get','task-get-multi','task-select','task-start','task-done','task-insert','task-import','task-update','task-reopen','task-unstart','task-list','task-summary','task-brief','task-worktree',
   'audit','insights','autoclose','backlog-scan','groom','check-deliverables','scope-paths','scope','scope-hint',
   'retro','retro-signals','retro-themes','retro-finding','retro-patches','skill-patch-priority','propose-work',
   'test-detect','test-precheck','add-lib','address-issue',
@@ -2091,6 +2091,7 @@ case "${1:-}" in
   task-start) shift; maybe_warn_skill_drift_at_task_start; exec python3 "$SCRIPT_DIR/tusk-task-start.py" "$DB_PATH" "$(resolve_config)" "$@" ;;
   task-done) shift; exec python3 "$SCRIPT_DIR/tusk-task-done.py" "$DB_PATH" "$(resolve_config)" "$@" ;;
   task-insert) shift; exec python3 "$SCRIPT_DIR/tusk-task-insert.py" "$DB_PATH" "$(resolve_config)" --repo-root "$REPO_ROOT" "$@" ;;
+  task-import) shift; exec python3 "$SCRIPT_DIR/tusk-task-import.py" "$DB_PATH" "$(resolve_config)" --repo-root "$REPO_ROOT" "$@" ;;
   task-update) shift; exec python3 "$SCRIPT_DIR/tusk-task-update.py" "$DB_PATH" "$(resolve_config)" "$@" ;;
   task-reopen) shift; exec python3 "$SCRIPT_DIR/tusk-task-reopen.py" "$DB_PATH" "$(resolve_config)" "$@" ;;
   task-unstart) shift; exec python3 "$SCRIPT_DIR/tusk-task-unstart.py" "$DB_PATH" "$(resolve_config)" "$@" ;;

--- a/bin/tusk-task-import.py
+++ b/bin/tusk-task-import.py
@@ -1,0 +1,563 @@
+#!/usr/bin/env python3
+"""Import tasks from structured JSON.
+
+Called by the tusk wrapper:
+    tusk task-import --file tasks.json [--dry-run]
+    tusk task-import --stdin [--dry-run]
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sqlite3
+import subprocess
+import sys
+from dataclasses import dataclass, field
+from typing import Any
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import tusk_loader  # loads hyphenated tusk modules
+
+_db_lib = tusk_loader.load("tusk-db-lib")
+get_connection = _db_lib.get_connection
+load_config = _db_lib.load_config
+validate_enum = _db_lib.validate_enum
+
+_json_lib = tusk_loader.load("tusk-json-lib")
+dumps = _json_lib.dumps
+
+_task_insert = tusk_loader.load("tusk-task-insert")
+TUSK_BIN = _task_insert.TUSK_BIN
+run_dupe_check = _task_insert.run_dupe_check
+reject_shell_metacharacters = _task_insert.reject_shell_metacharacters
+_canonical_enum_value = _task_insert._canonical_enum_value
+_repo_root = _task_insert._repo_root
+_warn_for_missing_declared_paths = _task_insert._warn_for_missing_declared_paths
+_warn_already_passing_criteria = _task_insert._warn_already_passing_criteria
+_auto_scope_candidates = _task_insert._auto_scope_candidates
+_resolve_auto_derived_scope_pattern = _task_insert._resolve_auto_derived_scope_pattern
+_UNIT_TEST_REQUIREMENT_RE = _task_insert._UNIT_TEST_REQUIREMENT_RE
+is_prose_identifier_path = _task_insert.is_prose_identifier_path
+_git_helpers = _task_insert._git_helpers
+
+
+@dataclass
+class ImportErrorItem:
+    field: str
+    message: str
+
+
+@dataclass
+class DependencyRef:
+    raw_index: int
+    key: str | None = None
+    task_id: int | None = None
+    relationship_type: str = "blocks"
+
+
+@dataclass
+class TaskPlan:
+    index: int
+    key: str | None
+    summary: str
+    description: str
+    priority: str
+    domain: str | None
+    task_type: str
+    assignee: str | None
+    complexity: str
+    workflow: str | None
+    criteria: list[str]
+    typed_criteria: list[dict[str, Any]]
+    duplicate_policy: str
+    deps: list[DependencyRef] = field(default_factory=list)
+    dupe: dict[str, Any] | None = None
+
+
+def _result_shell() -> dict[str, dict[str, Any]]:
+    return {"created": {}, "skipped": {}, "failed": {}}
+
+
+def _failure_entry(key: str | None, errors: list[ImportErrorItem]) -> dict[str, Any]:
+    entry: dict[str, Any] = {
+        "errors": [{"field": e.field, "message": e.message} for e in errors],
+    }
+    if key is not None:
+        entry["key"] = key
+    return entry
+
+
+def _load_json(args: argparse.Namespace) -> tuple[Any | None, list[ImportErrorItem]]:
+    try:
+        if args.stdin:
+            raw = sys.stdin.read()
+        else:
+            with open(args.file, "r", encoding="utf-8") as fh:
+                raw = fh.read()
+    except OSError as exc:
+        return None, [ImportErrorItem("$", f"unable to read input: {exc}")]
+
+    try:
+        return json.loads(raw), []
+    except json.JSONDecodeError as exc:
+        return None, [ImportErrorItem("$", f"malformed JSON: {exc.msg}")]
+
+
+def _as_nonempty_string(value: Any) -> str | None:
+    if not isinstance(value, str):
+        return None
+    stripped = value.strip()
+    return stripped or None
+
+
+def _normalize_criteria(raw: Any) -> tuple[list[str], list[dict[str, Any]], list[ImportErrorItem]]:
+    errors: list[ImportErrorItem] = []
+    criteria: list[str] = []
+    typed: list[dict[str, Any]] = []
+    if not isinstance(raw, list) or not raw:
+        return [], [], [ImportErrorItem("criteria", "at least one criterion is required")]
+
+    for i, item in enumerate(raw):
+        field = f"criteria[{i}]"
+        if isinstance(item, str):
+            text = item.strip()
+            if not text:
+                errors.append(ImportErrorItem(field, "criterion text is required"))
+            else:
+                criteria.append(item)
+            continue
+        if not isinstance(item, dict):
+            errors.append(ImportErrorItem(field, "criterion must be a string or object"))
+            continue
+        text = _as_nonempty_string(item.get("text"))
+        if text is None:
+            errors.append(ImportErrorItem(f"{field}.text", "criterion text is required"))
+            continue
+        criterion = {"text": text, "type": item.get("type", "manual"), "spec": item.get("spec")}
+        typed.append(criterion)
+    return criteria, typed, errors
+
+
+def _normalize_dependencies(raw: Any) -> tuple[list[DependencyRef], list[ImportErrorItem]]:
+    if raw is None:
+        return [], []
+    if not isinstance(raw, list):
+        return [], [ImportErrorItem("depends_on", "depends_on must be an array")]
+
+    deps: list[DependencyRef] = []
+    errors: list[ImportErrorItem] = []
+    for i, item in enumerate(raw):
+        field = f"depends_on[{i}]"
+        rel_type = "blocks"
+        key: str | None = None
+        task_id: int | None = None
+        if isinstance(item, str):
+            key = item
+        elif isinstance(item, int) and not isinstance(item, bool):
+            task_id = item
+        elif isinstance(item, dict):
+            rel_type = item.get("type", "blocks")
+            if "key" in item:
+                key = item.get("key")
+            elif "id" in item:
+                task_id = item.get("id")
+            else:
+                errors.append(ImportErrorItem(field, "dependency must include key or id"))
+                continue
+        else:
+            errors.append(ImportErrorItem(field, "dependency must be a key, id, or object"))
+            continue
+        if rel_type not in ("blocks", "contingent"):
+            errors.append(ImportErrorItem(f"{field}.type", "type must be 'blocks' or 'contingent'"))
+        if key is not None and not _as_nonempty_string(key):
+            errors.append(ImportErrorItem(field, "dependency key is required"))
+        if task_id is not None and (not isinstance(task_id, int) or isinstance(task_id, bool) or task_id <= 0):
+            errors.append(ImportErrorItem(field, "dependency id must be a positive integer"))
+        deps.append(DependencyRef(raw_index=i, key=key, task_id=task_id, relationship_type=rel_type))
+    return deps, errors
+
+
+def _validate_item(
+    item: Any,
+    index: int,
+    config: dict[str, Any],
+    known_keys: set[str],
+) -> tuple[TaskPlan | None, list[ImportErrorItem], str | None]:
+    if not isinstance(item, dict):
+        return None, [ImportErrorItem("$", "task must be an object")], None
+
+    key = item.get("key")
+    errors: list[ImportErrorItem] = []
+    if key is not None and not _as_nonempty_string(key):
+        errors.append(ImportErrorItem("key", "key must be a non-empty string"))
+        key = None
+
+    summary = _as_nonempty_string(item.get("summary"))
+    if summary is None:
+        errors.append(ImportErrorItem("summary", "summary is required"))
+        summary = ""
+    description = item.get("description")
+    if not isinstance(description, str):
+        errors.append(ImportErrorItem("description", "description is required"))
+        description = ""
+
+    criteria, typed_criteria, criterion_errors = _normalize_criteria(item.get("criteria"))
+    errors.extend(criterion_errors)
+
+    priority = _canonical_enum_value(item.get("priority", "Medium"), config.get("priorities", []))
+    task_type = item.get("task_type", item.get("task-type", "feature"))
+    complexity = item.get("complexity", "M")
+    domain = item.get("domain")
+    assignee = item.get("assignee")
+    workflow = item.get("workflow")
+
+    enum_checks = [
+        ("priority", priority, config.get("priorities", [])),
+        ("task_type", task_type, config.get("task_types", [])),
+        ("complexity", complexity, config.get("complexity", [])),
+    ]
+    if domain is not None:
+        enum_checks.append(("domain", domain, config.get("domains", [])))
+    if workflow is not None:
+        enum_checks.append(("workflow", workflow, config.get("workflows", [])))
+    agents = config.get("agents", {})
+    if assignee is not None and agents:
+        enum_checks.append(("assignee", assignee, list(agents.keys())))
+    for field_name, value, valid in enum_checks:
+        err = validate_enum(value, valid, field_name)
+        if err:
+            errors.append(ImportErrorItem(field_name, err))
+
+    duplicate_policy = item.get("duplicate_policy", "fail")
+    if duplicate_policy not in ("fail", "skip", "allow"):
+        errors.append(ImportErrorItem("duplicate_policy", "duplicate_policy must be fail, skip, or allow"))
+        duplicate_policy = "fail"
+
+    criterion_types = config.get("criterion_types", [])
+    for i, tc in enumerate(typed_criteria):
+        ct = tc.get("type", "manual")
+        spec = tc.get("spec")
+        if spec is not None and isinstance(spec, str) and not spec.strip():
+            tc["spec"] = None
+        if criterion_types and ct not in criterion_types:
+            errors.append(ImportErrorItem(f"criteria[{i}].type", f"invalid type '{ct}'"))
+        if ct in {"code", "test", "file"} and not tc.get("spec"):
+            errors.append(ImportErrorItem(f"criteria[{i}].spec", f"spec required for type '{ct}'"))
+
+    deps, dep_errors = _normalize_dependencies(item.get("depends_on"))
+    errors.extend(dep_errors)
+    for dep in deps:
+        if dep.key is None:
+            continue
+        field = f"depends_on[{dep.raw_index}]"
+        if dep.key not in known_keys:
+            errors.append(ImportErrorItem(field, f"unknown task key '{dep.key}'"))
+        elif key is not None and dep.key == key:
+            errors.append(ImportErrorItem(field, "task cannot depend on itself"))
+
+    metachar_checks = [("task summary", summary), ("task description", description)]
+    metachar_checks.extend(("criterion text", text) for text in criteria)
+    metachar_checks.extend(("criterion text", tc["text"]) for tc in typed_criteria)
+    for subject, text in metachar_checks:
+        ok, diagnostic = reject_shell_metacharacters(text, subject=subject)
+        if not ok:
+            errors.append(ImportErrorItem(subject, diagnostic))
+
+    if errors:
+        return None, errors, key
+
+    return TaskPlan(
+        index=index,
+        key=key,
+        summary=summary,
+        description=description,
+        priority=priority,
+        domain=domain,
+        task_type=task_type,
+        assignee=assignee,
+        complexity=complexity,
+        workflow=workflow,
+        criteria=criteria,
+        typed_criteria=typed_criteria,
+        duplicate_policy=duplicate_policy,
+        deps=deps,
+    ), [], key
+
+
+def _task_exists(conn: sqlite3.Connection, task_id: int) -> bool:
+    return conn.execute("SELECT 1 FROM tasks WHERE id = ?", (task_id,)).fetchone() is not None
+
+
+def _validate_dependency_references(
+    plans: list[TaskPlan],
+    conn: sqlite3.Connection,
+) -> dict[int, list[ImportErrorItem]]:
+    errors: dict[int, list[ImportErrorItem]] = {}
+    for plan in plans:
+        for dep in plan.deps:
+            field = f"depends_on[{dep.raw_index}]"
+            if dep.key is not None:
+                continue
+            elif dep.task_id is not None and not _task_exists(conn, dep.task_id):
+                errors.setdefault(plan.index, []).append(
+                    ImportErrorItem(field, f"task id {dep.task_id} does not exist")
+                )
+    return errors
+
+
+def _insert_task(conn: sqlite3.Connection, plan: TaskPlan, repo_root: str) -> tuple[int, list[int], list[tuple[int, str, str | None]]]:
+    conn.execute(
+        "INSERT INTO tasks (summary, description, status, priority, domain, "
+        "task_type, assignee, complexity, workflow, created_at, updated_at) "
+        "VALUES (?, ?, 'To Do', ?, ?, ?, ?, ?, ?, datetime('now'), datetime('now'))",
+        (
+            plan.summary,
+            plan.description,
+            plan.priority,
+            plan.domain,
+            plan.task_type,
+            plan.assignee,
+            plan.complexity,
+            plan.workflow,
+        ),
+    )
+    task_id = conn.execute("SELECT last_insert_rowid()").fetchone()[0]
+
+    criteria_ids: list[int] = []
+    typed_inserted: list[tuple[int, str, str | None]] = []
+    for criterion in plan.criteria:
+        conn.execute(
+            "INSERT INTO acceptance_criteria (task_id, criterion, source) VALUES (?, ?, 'original')",
+            (task_id, criterion),
+        )
+        criteria_ids.append(conn.execute("SELECT last_insert_rowid()").fetchone()[0])
+    for tc in plan.typed_criteria:
+        conn.execute(
+            "INSERT INTO acceptance_criteria "
+            "(task_id, criterion, source, criterion_type, verification_spec) "
+            "VALUES (?, ?, 'original', ?, ?)",
+            (task_id, tc["text"], tc.get("type", "manual"), tc.get("spec")),
+        )
+        cid = conn.execute("SELECT last_insert_rowid()").fetchone()[0]
+        criteria_ids.append(cid)
+        typed_inserted.append((cid, tc.get("type", "manual"), tc.get("spec")))
+
+    text_blocks = [plan.summary or "", plan.description or ""]
+    text_blocks.extend(plan.criteria)
+    for tc in plan.typed_criteria:
+        text_blocks.append(tc.get("text") or "")
+        text_blocks.append(tc.get("spec") or "")
+    seen_auto: set[str] = set()
+    requires_unit_tests = any(_UNIT_TEST_REQUIREMENT_RE.search(block or "") for block in text_blocks)
+    for text in text_blocks:
+        for candidate in _auto_scope_candidates(
+            text,
+            repo_root=repo_root,
+            task_type=plan.task_type,
+            requires_unit_tests=requires_unit_tests,
+        ):
+            resolved = _resolve_auto_derived_scope_pattern(repo_root, candidate)
+            is_explicit_github_path = candidate.startswith(".github/") and candidate != ".github/"
+            if not is_explicit_github_path and is_prose_identifier_path(candidate, repo_root):
+                continue
+            if resolved in _git_helpers.SCOPE_DERIVE_BOOKKEEPING_DENYLIST:
+                continue
+            if not _git_helpers.is_trackable_scope_pattern(repo_root, resolved):
+                continue
+            if resolved in seen_auto:
+                continue
+            seen_auto.add(resolved)
+            conn.execute(
+                "INSERT INTO task_scope (task_id, pattern, source) VALUES (?, ?, 'auto_derived')",
+                (task_id, resolved),
+            )
+
+    return task_id, criteria_ids, typed_inserted
+
+
+def _resolve_dep_id(dep: DependencyRef, key_to_created_id: dict[str, int]) -> int:
+    if dep.task_id is not None:
+        return dep.task_id
+    return key_to_created_id[dep.key or ""]
+
+
+def _execute_import(
+    db_path: str,
+    plans: list[TaskPlan],
+    result: dict[str, dict[str, Any]],
+    *,
+    dry_run: bool,
+    repo_root: str,
+) -> int:
+    if dry_run:
+        for plan in plans:
+            result["created"][str(plan.index)] = {"dry_run": True}
+            if plan.key is not None:
+                result["created"][str(plan.index)]["key"] = plan.key
+        return 0
+
+    conn = get_connection(db_path)
+    typed_inserted: list[tuple[int, str, str | None]] = []
+    key_to_created_id: dict[str, int] = {}
+    index_to_created_id: dict[int, int] = {}
+    try:
+        for plan in plans:
+            task_id, criteria_ids, typed = _insert_task(conn, plan, repo_root)
+            typed_inserted.extend(typed)
+            index_to_created_id[plan.index] = task_id
+            if plan.key is not None:
+                key_to_created_id[plan.key] = task_id
+            entry = {"task_id": task_id, "criteria_ids": criteria_ids}
+            if plan.key is not None:
+                entry["key"] = plan.key
+            result["created"][str(plan.index)] = entry
+
+        for plan in plans:
+            task_id = index_to_created_id[plan.index]
+            for dep in plan.deps:
+                conn.execute(
+                    "INSERT OR IGNORE INTO task_dependencies "
+                    "(task_id, depends_on_id, relationship_type) VALUES (?, ?, ?)",
+                    (task_id, _resolve_dep_id(dep, key_to_created_id), dep.relationship_type),
+                )
+        conn.commit()
+    except sqlite3.Error as exc:
+        conn.rollback()
+        result["failed"]["0"] = _failure_entry(None, [ImportErrorItem("$", f"database error: {exc}")])
+        return 2
+    finally:
+        conn.close()
+
+    _warn_already_passing_criteria(typed_inserted)
+    subprocess.run([TUSK_BIN, "wsjf"], capture_output=True)
+    return 0
+
+
+def main(argv: list[str]) -> int:
+    db_path = argv[0]
+    config_path = argv[1]
+    parser = argparse.ArgumentParser(
+        allow_abbrev=False,
+        prog="tusk task-import",
+        description="Import tasks from a JSON plan",
+    )
+    source = parser.add_mutually_exclusive_group(required=True)
+    source.add_argument("--file", help="Read import JSON from a UTF-8 file")
+    source.add_argument("--stdin", action="store_true", help="Read import JSON from stdin")
+    parser.add_argument("--dry-run", action="store_true", help="Validate without writing rows")
+    parser.add_argument("--repo-root", default=None, help=argparse.SUPPRESS)
+    args = parser.parse_args(argv[2:])
+
+    result = _result_shell()
+    loaded, load_errors = _load_json(args)
+    if load_errors:
+        result["failed"]["0"] = _failure_entry(None, load_errors)
+        print(dumps(result))
+        return 2
+    if not isinstance(loaded, dict):
+        result["failed"]["0"] = _failure_entry(None, [ImportErrorItem("$", "top-level JSON must be an object")])
+        print(dumps(result))
+        return 2
+    tasks = loaded.get("tasks")
+    if not isinstance(tasks, list):
+        result["failed"]["0"] = _failure_entry(None, [ImportErrorItem("tasks", "top-level tasks array is required")])
+        print(dumps(result))
+        return 2
+
+    config = load_config(config_path)
+    repo_root = _repo_root(config_path, args.repo_root)
+    plans: list[TaskPlan] = []
+    seen_keys: set[str] = set()
+    known_keys = {
+        item.get("key")
+        for item in tasks
+        if isinstance(item, dict) and _as_nonempty_string(item.get("key"))
+    }
+    for index, item in enumerate(tasks):
+        plan, errors, key = _validate_item(item, index, config, known_keys)
+        if key is not None:
+            if key in seen_keys:
+                errors.append(ImportErrorItem("key", f"duplicate key '{key}'"))
+            seen_keys.add(key)
+        if errors:
+            result["failed"][str(index)] = _failure_entry(key, errors)
+            continue
+        plans.append(plan)
+
+    conn = get_connection(db_path)
+    try:
+        dep_errors = _validate_dependency_references(plans, conn)
+    finally:
+        conn.close()
+    for index, errors in dep_errors.items():
+        result["failed"][str(index)] = _failure_entry(
+            next((p.key for p in plans if p.index == index), None),
+            errors,
+        )
+    plans = [p for p in plans if str(p.index) not in result["failed"]]
+
+    for plan in list(plans):
+        if plan.duplicate_policy == "allow":
+            continue
+        dupe = run_dupe_check(plan.summary, plan.domain)
+        if not dupe:
+            continue
+        plan.dupe = dupe
+        if plan.duplicate_policy == "skip":
+            entry = {
+                "reason": "duplicate",
+                "matched_task_id": dupe.get("id"),
+                "matched_summary": dupe.get("summary", ""),
+                "similarity": dupe.get("similarity", 0),
+            }
+            if plan.key is not None:
+                entry["key"] = plan.key
+            result["skipped"][str(plan.index)] = entry
+            plans.remove(plan)
+        else:
+            result["failed"][str(plan.index)] = _failure_entry(
+                plan.key,
+                [ImportErrorItem("duplicate_policy", f"duplicate of TASK-{dupe.get('id')}")],
+            )
+            plans.remove(plan)
+
+    remaining_keys = {plan.key for plan in plans if plan.key is not None}
+    skipped_keys = {
+        entry.get("key")
+        for entry in result["skipped"].values()
+        if entry.get("key") is not None
+    }
+    for plan in list(plans):
+        errors: list[ImportErrorItem] = []
+        for dep in plan.deps:
+            if dep.key is None or dep.key in remaining_keys:
+                continue
+            field = f"depends_on[{dep.raw_index}]"
+            if dep.key in skipped_keys:
+                errors.append(ImportErrorItem(field, f"dependency key '{dep.key}' was skipped"))
+            else:
+                errors.append(ImportErrorItem(field, f"unknown task key '{dep.key}'"))
+        if errors:
+            result["failed"][str(plan.index)] = _failure_entry(plan.key, errors)
+            plans.remove(plan)
+
+    for plan in plans:
+        _warn_for_missing_declared_paths(repo_root, [], plan.typed_criteria)
+
+    if result["failed"]:
+        print(dumps(result))
+        return 2
+
+    code = _execute_import(db_path, plans, result, dry_run=args.dry_run, repo_root=repo_root)
+    print(dumps(result))
+    return code
+
+
+if __name__ == "__main__":
+    if len(sys.argv) < 2 or not sys.argv[1].endswith(".db"):
+        print("Error: This script must be invoked via the tusk wrapper.", file=sys.stderr)
+        print("Use: tusk task-import --file tasks.json [--dry-run]", file=sys.stderr)
+        sys.exit(1)
+    sys.exit(main(sys.argv[1:]))

--- a/tests/unit/test_task_import.py
+++ b/tests/unit/test_task_import.py
@@ -1,0 +1,268 @@
+"""Unit coverage for ``tusk task-import`` JSON parsing and dry-run validation."""
+
+import importlib.util
+import json
+import os
+import sqlite3
+import sys
+from contextlib import redirect_stderr, redirect_stdout
+from io import StringIO
+from unittest.mock import patch
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+_spec_import = importlib.util.spec_from_file_location(
+    "tusk_task_import",
+    os.path.join(REPO_ROOT, "bin", "tusk-task-import.py"),
+)
+import_mod = importlib.util.module_from_spec(_spec_import)
+sys.modules[_spec_import.name] = import_mod
+_spec_import.loader.exec_module(import_mod)
+
+
+def _write_config(path, **overrides):
+    cfg = {
+        "domains": ["cli", "docs"],
+        "task_types": ["feature", "bug"],
+        "statuses": ["To Do", "In Progress", "Done"],
+        "priorities": ["High", "Medium", "Low"],
+        "closed_reasons": ["completed"],
+        "complexity": ["S", "M", "L"],
+        "workflows": ["planning"],
+        "criterion_types": ["manual", "code", "test", "file"],
+        "agents": {"codex": {}},
+    }
+    cfg.update(overrides)
+    path.write_text(json.dumps(cfg), encoding="utf-8")
+    return str(path)
+
+
+def _make_db(tmp_path):
+    db_path = tmp_path / "tusk" / "tasks.db"
+    db_path.parent.mkdir()
+    conn = sqlite3.connect(db_path)
+    conn.executescript(
+        """
+        CREATE TABLE tasks (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            summary TEXT NOT NULL,
+            description TEXT,
+            status TEXT DEFAULT 'To Do',
+            priority TEXT DEFAULT 'Medium',
+            domain TEXT,
+            assignee TEXT,
+            task_type TEXT,
+            priority_score INTEGER DEFAULT 0,
+            expires_at TEXT,
+            not_before TEXT,
+            closed_reason TEXT,
+            complexity TEXT,
+            workflow TEXT,
+            created_at TEXT DEFAULT (datetime('now')),
+            updated_at TEXT DEFAULT (datetime('now')),
+            started_at TEXT,
+            closed_at TEXT,
+            merge_commit_sha TEXT,
+            merge_base_sha TEXT,
+            fixes_task_id INTEGER REFERENCES tasks(id) ON DELETE SET NULL,
+            bakeoff_id INTEGER,
+            bakeoff_shadow INTEGER NOT NULL DEFAULT 0 CHECK (bakeoff_shadow IN (0, 1)),
+            scope_enforced INTEGER NOT NULL DEFAULT 1 CHECK (scope_enforced IN (0, 1))
+        );
+        CREATE TABLE acceptance_criteria (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            task_id INTEGER,
+            criterion TEXT,
+            source TEXT DEFAULT 'original',
+            is_completed INTEGER DEFAULT 0,
+            is_deferred INTEGER DEFAULT 0,
+            deferred_reason TEXT,
+            criterion_type TEXT DEFAULT 'manual',
+            verification_spec TEXT,
+            verification_result TEXT,
+            commit_hash TEXT,
+            committed_at TEXT,
+            completed_at TEXT,
+            updated_at TEXT,
+            cost_dollars REAL,
+            tokens_in INTEGER,
+            tokens_out INTEGER
+        );
+        CREATE TABLE task_dependencies (
+            task_id INTEGER NOT NULL,
+            depends_on_id INTEGER NOT NULL,
+            relationship_type TEXT DEFAULT 'blocks',
+            PRIMARY KEY (task_id, depends_on_id)
+        );
+        CREATE TABLE task_scope (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            task_id INTEGER NOT NULL,
+            pattern TEXT NOT NULL,
+            source TEXT NOT NULL,
+            reason TEXT,
+            locked_at TEXT,
+            locked_by TEXT,
+            created_at TEXT DEFAULT (datetime('now'))
+        );
+        """
+    )
+    conn.commit()
+    conn.close()
+    return str(db_path)
+
+
+def _run_import(db_path, config_path, argv, *, dupes=None):
+    out = StringIO()
+    err = StringIO()
+    with redirect_stdout(out), redirect_stderr(err), \
+            patch.object(import_mod, "run_dupe_check", side_effect=dupes or (lambda summary, domain: None)), \
+            patch("subprocess.run"):
+        code = import_mod.main([db_path, config_path, *argv])
+    payload = json.loads(out.getvalue()) if out.getvalue().strip() else None
+    return code, payload, err.getvalue()
+
+
+def test_malformed_json_reports_validation_error(tmp_path):
+    db_path = _make_db(tmp_path)
+    config_path = _write_config(tmp_path / "config.json")
+    plan = tmp_path / "tasks.json"
+    plan.write_text('{"tasks": [', encoding="utf-8")
+
+    code, payload, err = _run_import(db_path, config_path, ["--file", str(plan), "--dry-run"])
+
+    assert code == 2
+    assert payload["failed"]["0"]["errors"][0]["field"] == "$"
+    assert "malformed JSON" in payload["failed"]["0"]["errors"][0]["message"]
+    assert err == ""
+
+
+def test_schema_errors_are_keyed_by_input_index_and_key(tmp_path):
+    db_path = _make_db(tmp_path)
+    config_path = _write_config(tmp_path / "config.json")
+    plan = tmp_path / "tasks.json"
+    plan.write_text(
+        json.dumps({
+            "tasks": [
+                {
+                    "key": "bad",
+                    "summary": "",
+                    "description": "Description",
+                    "priority": "Urgent",
+                    "domain": "mobile",
+                    "criteria": [{"text": "Needs spec", "type": "test"}],
+                    "duplicate_policy": "maybe",
+                    "depends_on": ["missing"],
+                }
+            ]
+        }),
+        encoding="utf-8",
+    )
+
+    code, payload, _err = _run_import(db_path, config_path, ["--file", str(plan), "--dry-run"])
+
+    assert code == 2
+    assert payload["created"] == {}
+    assert payload["skipped"] == {}
+    failed = payload["failed"]["0"]
+    assert failed["key"] == "bad"
+    messages = {error["field"]: error["message"] for error in failed["errors"]}
+    assert messages["summary"] == "summary is required"
+    assert "Invalid priority" in messages["priority"]
+    assert "Invalid domain" in messages["domain"]
+    assert messages["criteria[0].spec"] == "spec required for type 'test'"
+    assert "duplicate_policy" in messages["duplicate_policy"]
+    assert messages["depends_on[0]"] == "unknown task key 'missing'"
+
+
+def test_dry_run_validates_without_writing_rows_and_reports_duplicates(tmp_path):
+    db_path = _make_db(tmp_path)
+    config_path = _write_config(tmp_path / "config.json")
+    conn = sqlite3.connect(db_path)
+    conn.execute(
+        "INSERT INTO tasks (summary, description, status) VALUES (?, ?, 'To Do')",
+        ("Existing dependency", "Already there"),
+    )
+    conn.commit()
+    conn.close()
+    plan = tmp_path / "tasks.json"
+    plan.write_text(
+        json.dumps({
+            "tasks": [
+                {
+                    "key": "base",
+                    "summary": "Base import task",
+                    "description": "Description",
+                    "domain": "cli",
+                    "criteria": ["Manual criterion"],
+                    "depends_on": [{"id": 1, "type": "contingent"}],
+                },
+                {
+                    "key": "dupe",
+                    "summary": "Duplicate import task",
+                    "description": "Description",
+                    "criteria": ["Manual criterion"],
+                    "duplicate_policy": "skip",
+                },
+            ]
+        }),
+        encoding="utf-8",
+    )
+
+    def dupes(summary, domain):
+        if summary == "Duplicate import task":
+            return {"id": 42, "summary": "Matched", "similarity": 0.91}
+        return None
+
+    code, payload, _err = _run_import(db_path, config_path, ["--file", str(plan), "--dry-run"], dupes=dupes)
+
+    assert code == 0
+    assert payload["created"]["0"] == {"key": "base", "dry_run": True}
+    assert payload["skipped"]["1"]["key"] == "dupe"
+    assert payload["skipped"]["1"]["reason"] == "duplicate"
+    conn = sqlite3.connect(db_path)
+    assert conn.execute("SELECT COUNT(*) FROM tasks").fetchone()[0] == 1
+    assert conn.execute("SELECT COUNT(*) FROM acceptance_criteria").fetchone()[0] == 0
+    assert conn.execute("SELECT COUNT(*) FROM task_dependencies").fetchone()[0] == 0
+    conn.close()
+
+
+def test_import_accepts_json_from_stdin_and_writes_rows(tmp_path, monkeypatch):
+    db_path = _make_db(tmp_path)
+    config_path = _write_config(tmp_path / "config.json")
+    monkeypatch.setattr(
+        "sys.stdin",
+        StringIO(json.dumps({
+            "tasks": [
+                {
+                    "key": "base",
+                    "summary": "Base import task",
+                    "description": "Description",
+                    "priority": "High",
+                    "domain": "cli",
+                    "criteria": ["Manual criterion"],
+                },
+                {
+                    "key": "child",
+                    "summary": "Child import task",
+                    "description": "Description",
+                    "criteria": [{"text": "Run unit test", "type": "test", "spec": "pytest"}],
+                    "depends_on": ["base"],
+                },
+            ]
+        })),
+    )
+
+    code, payload, _err = _run_import(db_path, config_path, ["--stdin"])
+
+    assert code == 0
+    assert payload["created"]["0"]["key"] == "base"
+    assert payload["created"]["0"]["task_id"] == 1
+    assert payload["created"]["1"]["key"] == "child"
+    assert payload["created"]["1"]["task_id"] == 2
+    conn = sqlite3.connect(db_path)
+    assert conn.execute("SELECT COUNT(*) FROM tasks").fetchone()[0] == 2
+    assert conn.execute("SELECT COUNT(*) FROM acceptance_criteria").fetchone()[0] == 2
+    assert conn.execute(
+        "SELECT relationship_type FROM task_dependencies WHERE task_id = 2 AND depends_on_id = 1"
+    ).fetchone()[0] == "blocks"
+    conn.close()


### PR DESCRIPTION
## Summary
- Add tusk task-import for JSON plans from --file or --stdin
- Validate schemas, enums, criteria specs, duplicate policies, and dependency references before writes
- Emit compact per-index JSON results for created, skipped, and failed rows

## Test plan
- [x] python3 -m pytest tests/unit/test_task_import.py -q
- [x] python3 -m pytest tests/unit/test_workflow.py tests/unit/test_argparse_no_abbrev.py -q
- [x] python3 -m pytest tests/unit/ -q
- [x] ./bin/tusk lint