### PR TITLE
[TASK-771] Materialize task-import through task-insert

### DIFF
--- a/bin/tusk-task-import.py
+++ b/bin/tusk-task-import.py
@@ -33,14 +33,12 @@ TUSK_BIN = _task_insert.TUSK_BIN
 run_dupe_check = _task_insert.run_dupe_check
 reject_shell_metacharacters = _task_insert.reject_shell_metacharacters
 _canonical_enum_value = _task_insert._canonical_enum_value
+_expand_scope_patterns = _task_insert._expand_scope_patterns
+_parse_not_before = _task_insert._parse_not_before
 _repo_root = _task_insert._repo_root
 _warn_for_missing_declared_paths = _task_insert._warn_for_missing_declared_paths
 _warn_already_passing_criteria = _task_insert._warn_already_passing_criteria
-_auto_scope_candidates = _task_insert._auto_scope_candidates
-_resolve_auto_derived_scope_pattern = _task_insert._resolve_auto_derived_scope_pattern
-_UNIT_TEST_REQUIREMENT_RE = _task_insert._UNIT_TEST_REQUIREMENT_RE
-is_prose_identifier_path = _task_insert.is_prose_identifier_path
-_git_helpers = _task_insert._git_helpers
+insert_task_record = _task_insert.insert_task_record
 
 
 @dataclass
@@ -69,6 +67,12 @@ class TaskPlan:
     assignee: str | None
     complexity: str
     workflow: str | None
+    expires_in_days: int | None
+    not_before: str | None
+    fixes_task_id: int | None
+    scope_patterns: list[str]
+    creates_paths: list[str]
+    unbounded: bool
     criteria: list[str]
     typed_criteria: list[dict[str, Any]]
     duplicate_policy: str
@@ -179,6 +183,53 @@ def _normalize_dependencies(raw: Any) -> tuple[list[DependencyRef], list[ImportE
     return deps, errors
 
 
+def _normalize_string_list(raw: Any, field_name: str) -> tuple[list[str], list[ImportErrorItem]]:
+    if raw is None:
+        return [], []
+    if isinstance(raw, str):
+        return [raw], []
+    if not isinstance(raw, list):
+        return [], [ImportErrorItem(field_name, f"{field_name} must be a string or array")]
+
+    values: list[str] = []
+    errors: list[ImportErrorItem] = []
+    for i, item in enumerate(raw):
+        text = _as_nonempty_string(item)
+        if text is None:
+            errors.append(ImportErrorItem(f"{field_name}[{i}]", f"{field_name} value is required"))
+        else:
+            values.append(text)
+    return values, errors
+
+
+def _normalize_expires_in(raw: Any) -> tuple[int | None, list[ImportErrorItem]]:
+    if raw is None:
+        return None, []
+    if not isinstance(raw, int) or isinstance(raw, bool):
+        return None, [ImportErrorItem("expires_in", "expires_in must be an integer number of days")]
+    return raw, []
+
+
+def _normalize_not_before(raw: Any) -> tuple[str | None, list[ImportErrorItem]]:
+    if raw is None:
+        return None, []
+    text = _as_nonempty_string(raw)
+    if text is None:
+        return None, [ImportErrorItem("not_before", "not_before must be a non-empty string")]
+    try:
+        return _parse_not_before(text), []
+    except argparse.ArgumentTypeError as exc:
+        return None, [ImportErrorItem("not_before", str(exc))]
+
+
+def _normalize_positive_int(raw: Any, field_name: str) -> tuple[int | None, list[ImportErrorItem]]:
+    if raw is None:
+        return None, []
+    if not isinstance(raw, int) or isinstance(raw, bool) or raw <= 0:
+        return None, [ImportErrorItem(field_name, f"{field_name} must be a positive integer")]
+    return raw, []
+
+
 def _validate_item(
     item: Any,
     index: int,
@@ -212,6 +263,21 @@ def _validate_item(
     domain = item.get("domain")
     assignee = item.get("assignee")
     workflow = item.get("workflow")
+    expires_in_days, expires_errors = _normalize_expires_in(item.get("expires_in"))
+    errors.extend(expires_errors)
+    not_before, not_before_errors = _normalize_not_before(item.get("not_before"))
+    errors.extend(not_before_errors)
+    fixes_task_id, fixes_errors = _normalize_positive_int(item.get("fixes_task_id"), "fixes_task_id")
+    errors.extend(fixes_errors)
+    raw_scope, scope_errors = _normalize_string_list(item.get("scope"), "scope")
+    errors.extend(scope_errors)
+    scope_patterns = _expand_scope_patterns(raw_scope)
+    creates_paths, creates_errors = _normalize_string_list(item.get("creates"), "creates")
+    errors.extend(creates_errors)
+    unbounded = item.get("unbounded", False)
+    if not isinstance(unbounded, bool):
+        errors.append(ImportErrorItem("unbounded", "unbounded must be true or false"))
+        unbounded = False
 
     enum_checks = [
         ("priority", priority, config.get("priorities", [])),
@@ -279,6 +345,12 @@ def _validate_item(
         assignee=assignee,
         complexity=complexity,
         workflow=workflow,
+        expires_in_days=expires_in_days,
+        not_before=not_before,
+        fixes_task_id=fixes_task_id,
+        scope_patterns=scope_patterns,
+        creates_paths=creates_paths,
+        unbounded=unbounded,
         criteria=criteria,
         typed_criteria=typed_criteria,
         duplicate_policy=duplicate_policy,
@@ -307,74 +379,32 @@ def _validate_dependency_references(
     return errors
 
 
-def _insert_task(conn: sqlite3.Connection, plan: TaskPlan, repo_root: str) -> tuple[int, list[int], list[tuple[int, str, str | None]]]:
-    conn.execute(
-        "INSERT INTO tasks (summary, description, status, priority, domain, "
-        "task_type, assignee, complexity, workflow, created_at, updated_at) "
-        "VALUES (?, ?, 'To Do', ?, ?, ?, ?, ?, ?, datetime('now'), datetime('now'))",
-        (
-            plan.summary,
-            plan.description,
-            plan.priority,
-            plan.domain,
-            plan.task_type,
-            plan.assignee,
-            plan.complexity,
-            plan.workflow,
-        ),
+def _materialize_task(
+    conn: sqlite3.Connection,
+    plan: TaskPlan,
+    repo_root: str,
+) -> tuple[int, list[int], list[tuple[int, str, str | None]]]:
+    inserted = insert_task_record(
+        conn,
+        summary=plan.summary,
+        description=plan.description,
+        priority=plan.priority,
+        domain=plan.domain,
+        task_type=plan.task_type,
+        assignee=plan.assignee,
+        complexity=plan.complexity,
+        workflow=plan.workflow,
+        criteria=plan.criteria,
+        typed_criteria=plan.typed_criteria,
+        repo_root=repo_root,
+        expires_in_days=plan.expires_in_days,
+        not_before=plan.not_before,
+        fixes_task_id=plan.fixes_task_id,
+        scope_patterns=plan.scope_patterns,
+        creates_paths=plan.creates_paths,
+        unbounded=plan.unbounded,
     )
-    task_id = conn.execute("SELECT last_insert_rowid()").fetchone()[0]
-
-    criteria_ids: list[int] = []
-    typed_inserted: list[tuple[int, str, str | None]] = []
-    for criterion in plan.criteria:
-        conn.execute(
-            "INSERT INTO acceptance_criteria (task_id, criterion, source) VALUES (?, ?, 'original')",
-            (task_id, criterion),
-        )
-        criteria_ids.append(conn.execute("SELECT last_insert_rowid()").fetchone()[0])
-    for tc in plan.typed_criteria:
-        conn.execute(
-            "INSERT INTO acceptance_criteria "
-            "(task_id, criterion, source, criterion_type, verification_spec) "
-            "VALUES (?, ?, 'original', ?, ?)",
-            (task_id, tc["text"], tc.get("type", "manual"), tc.get("spec")),
-        )
-        cid = conn.execute("SELECT last_insert_rowid()").fetchone()[0]
-        criteria_ids.append(cid)
-        typed_inserted.append((cid, tc.get("type", "manual"), tc.get("spec")))
-
-    text_blocks = [plan.summary or "", plan.description or ""]
-    text_blocks.extend(plan.criteria)
-    for tc in plan.typed_criteria:
-        text_blocks.append(tc.get("text") or "")
-        text_blocks.append(tc.get("spec") or "")
-    seen_auto: set[str] = set()
-    requires_unit_tests = any(_UNIT_TEST_REQUIREMENT_RE.search(block or "") for block in text_blocks)
-    for text in text_blocks:
-        for candidate in _auto_scope_candidates(
-            text,
-            repo_root=repo_root,
-            task_type=plan.task_type,
-            requires_unit_tests=requires_unit_tests,
-        ):
-            resolved = _resolve_auto_derived_scope_pattern(repo_root, candidate)
-            is_explicit_github_path = candidate.startswith(".github/") and candidate != ".github/"
-            if not is_explicit_github_path and is_prose_identifier_path(candidate, repo_root):
-                continue
-            if resolved in _git_helpers.SCOPE_DERIVE_BOOKKEEPING_DENYLIST:
-                continue
-            if not _git_helpers.is_trackable_scope_pattern(repo_root, resolved):
-                continue
-            if resolved in seen_auto:
-                continue
-            seen_auto.add(resolved)
-            conn.execute(
-                "INSERT INTO task_scope (task_id, pattern, source) VALUES (?, ?, 'auto_derived')",
-                (task_id, resolved),
-            )
-
-    return task_id, criteria_ids, typed_inserted
+    return inserted.task_id, inserted.criteria_ids, inserted.typed_inserted
 
 
 def _resolve_dep_id(dep: DependencyRef, key_to_created_id: dict[str, int]) -> int:
@@ -390,39 +420,76 @@ def _execute_import(
     *,
     dry_run: bool,
     repo_root: str,
+    best_effort: bool,
 ) -> int:
     if dry_run:
         for plan in plans:
             result["created"][str(plan.index)] = {"dry_run": True}
             if plan.key is not None:
                 result["created"][str(plan.index)]["key"] = plan.key
-        return 0
+        return 2 if result["failed"] else 0
 
-    conn = get_connection(db_path)
     typed_inserted: list[tuple[int, str, str | None]] = []
     key_to_created_id: dict[str, int] = {}
     index_to_created_id: dict[int, int] = {}
+    conn = get_connection(db_path)
     try:
         for plan in plans:
-            task_id, criteria_ids, typed = _insert_task(conn, plan, repo_root)
-            typed_inserted.extend(typed)
-            index_to_created_id[plan.index] = task_id
-            if plan.key is not None:
-                key_to_created_id[plan.key] = task_id
-            entry = {"task_id": task_id, "criteria_ids": criteria_ids}
-            if plan.key is not None:
-                entry["key"] = plan.key
-            result["created"][str(plan.index)] = entry
+            try:
+                task_id, criteria_ids, typed = _materialize_task(conn, plan, repo_root)
+                if best_effort:
+                    conn.commit()
+                typed_inserted.extend(typed)
+                index_to_created_id[plan.index] = task_id
+                if plan.key is not None:
+                    key_to_created_id[plan.key] = task_id
+                entry = {"task_id": task_id, "criteria_ids": criteria_ids}
+                if plan.key is not None:
+                    entry["key"] = plan.key
+                result["created"][str(plan.index)] = entry
+            except ValueError as exc:
+                conn.rollback()
+                result["failed"][str(plan.index)] = _failure_entry(
+                    plan.key,
+                    [ImportErrorItem("$", str(exc))],
+                )
+                if not best_effort:
+                    result["created"].clear()
+                    return 2
+            except sqlite3.Error as exc:
+                conn.rollback()
+                result["failed"][str(plan.index)] = _failure_entry(
+                    plan.key,
+                    [ImportErrorItem("$", f"database error: {exc}")],
+                )
+                if not best_effort:
+                    result["created"].clear()
+                    return 2
 
         for plan in plans:
+            if plan.index not in index_to_created_id:
+                continue
             task_id = index_to_created_id[plan.index]
-            for dep in plan.deps:
-                conn.execute(
-                    "INSERT OR IGNORE INTO task_dependencies "
-                    "(task_id, depends_on_id, relationship_type) VALUES (?, ?, ?)",
-                    (task_id, _resolve_dep_id(dep, key_to_created_id), dep.relationship_type),
+            try:
+                for dep in plan.deps:
+                    conn.execute(
+                        "INSERT OR IGNORE INTO task_dependencies "
+                        "(task_id, depends_on_id, relationship_type) VALUES (?, ?, ?)",
+                        (task_id, _resolve_dep_id(dep, key_to_created_id), dep.relationship_type),
+                    )
+                if best_effort:
+                    conn.commit()
+            except sqlite3.Error as exc:
+                conn.rollback()
+                result["failed"][str(plan.index)] = _failure_entry(
+                    plan.key,
+                    [ImportErrorItem("$", f"database error: {exc}")],
                 )
-        conn.commit()
+                if not best_effort:
+                    result["created"].clear()
+                    return 2
+        if not best_effort:
+            conn.commit()
     except sqlite3.Error as exc:
         conn.rollback()
         result["failed"]["0"] = _failure_entry(None, [ImportErrorItem("$", f"database error: {exc}")])
@@ -432,7 +499,7 @@ def _execute_import(
 
     _warn_already_passing_criteria(typed_inserted)
     subprocess.run([TUSK_BIN, "wsjf"], capture_output=True)
-    return 0
+    return 2 if result["failed"] else 0
 
 
 def main(argv: list[str]) -> int:
@@ -447,6 +514,11 @@ def main(argv: list[str]) -> int:
     source.add_argument("--file", help="Read import JSON from a UTF-8 file")
     source.add_argument("--stdin", action="store_true", help="Read import JSON from stdin")
     parser.add_argument("--dry-run", action="store_true", help="Validate without writing rows")
+    parser.add_argument(
+        "--best-effort",
+        action="store_true",
+        help="Create valid tasks and report per-task failures instead of rolling back the full batch",
+    )
     parser.add_argument("--repo-root", default=None, help=argparse.SUPPRESS)
     args = parser.parse_args(argv[2:])
 
@@ -544,13 +616,20 @@ def main(argv: list[str]) -> int:
             plans.remove(plan)
 
     for plan in plans:
-        _warn_for_missing_declared_paths(repo_root, [], plan.typed_criteria)
+        _warn_for_missing_declared_paths(repo_root, plan.scope_patterns, plan.typed_criteria)
 
-    if result["failed"]:
+    if result["failed"] and not args.best_effort:
         print(dumps(result))
         return 2
 
-    code = _execute_import(db_path, plans, result, dry_run=args.dry_run, repo_root=repo_root)
+    code = _execute_import(
+        db_path,
+        plans,
+        result,
+        dry_run=args.dry_run,
+        repo_root=repo_root,
+        best_effort=args.best_effort,
+    )
     print(dumps(result))
     return code
 

--- a/bin/tusk-task-insert.py
+++ b/bin/tusk-task-insert.py
@@ -22,6 +22,7 @@ Exit codes:
 """
 
 import argparse
+from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 import json
 import os
@@ -901,6 +902,182 @@ def _canonical_enum_value(value: str, valid_values: list[str]) -> str:
     return value
 
 
+@dataclass
+class InsertTaskResult:
+    task_id: int
+    criteria_ids: list[int]
+    typed_inserted: list[tuple[int, str, str | None]]
+
+
+def insert_task_record(
+    conn: sqlite3.Connection,
+    *,
+    summary: str,
+    description: str,
+    priority: str,
+    domain: str | None,
+    task_type: str,
+    assignee: str | None,
+    complexity: str,
+    workflow: str | None,
+    criteria: list[str],
+    typed_criteria: list[dict],
+    repo_root: str | None,
+    expires_in_days: int | None = None,
+    not_before: str | None = None,
+    fixes_task_id: int | None = None,
+    scope_patterns: list[str] | None = None,
+    creates_paths: list[str] | None = None,
+    unbounded: bool = False,
+) -> InsertTaskResult:
+    """Insert a task using the same DB semantics as ``tusk task-insert``."""
+    scope_patterns = scope_patterns or []
+    creates_paths = creates_paths or []
+
+    if fixes_task_id is not None:
+        row = conn.execute(
+            "SELECT 1 FROM tasks WHERE id = ?", (fixes_task_id,)
+        ).fetchone()
+        if row is None:
+            raise ValueError(
+                f"--fixes-task-id {fixes_task_id} does not reference an existing task"
+            )
+
+    expires_at_expr = None
+    if expires_in_days is not None:
+        expires_at_expr = f"+{expires_in_days} days"
+
+    if expires_at_expr:
+        conn.execute(
+            "INSERT INTO tasks (summary, description, status, priority, domain, "
+            "task_type, assignee, complexity, workflow, fixes_task_id, "
+            "expires_at, not_before, created_at, updated_at) "
+            "VALUES (?, ?, 'To Do', ?, ?, ?, ?, ?, ?, ?, datetime('now', ?), "
+            "?, datetime('now'), datetime('now'))",
+            (
+                summary,
+                description,
+                priority,
+                domain,
+                task_type,
+                assignee,
+                complexity,
+                workflow,
+                fixes_task_id,
+                expires_at_expr,
+                not_before,
+            ),
+        )
+    else:
+        conn.execute(
+            "INSERT INTO tasks (summary, description, status, priority, domain, "
+            "task_type, assignee, complexity, workflow, fixes_task_id, "
+            "not_before, created_at, updated_at) "
+            "VALUES (?, ?, 'To Do', ?, ?, ?, ?, ?, ?, ?, ?, datetime('now'), datetime('now'))",
+            (
+                summary,
+                description,
+                priority,
+                domain,
+                task_type,
+                assignee,
+                complexity,
+                workflow,
+                fixes_task_id,
+                not_before,
+            ),
+        )
+
+    task_id = conn.execute("SELECT last_insert_rowid()").fetchone()[0]
+
+    criteria_ids = []
+    for criterion in criteria:
+        conn.execute(
+            "INSERT INTO acceptance_criteria (task_id, criterion, source) "
+            "VALUES (?, ?, 'original')",
+            (task_id, criterion),
+        )
+        cid = conn.execute("SELECT last_insert_rowid()").fetchone()[0]
+        criteria_ids.append(cid)
+
+    typed_inserted = []
+    for tc in typed_criteria:
+        conn.execute(
+            "INSERT INTO acceptance_criteria "
+            "(task_id, criterion, source, criterion_type, verification_spec) "
+            "VALUES (?, ?, 'original', ?, ?)",
+            (task_id, tc["text"], tc.get("type", "manual"), tc.get("spec")),
+        )
+        cid = conn.execute("SELECT last_insert_rowid()").fetchone()[0]
+        criteria_ids.append(cid)
+        typed_inserted.append((cid, tc.get("type", "manual"), tc.get("spec")))
+
+    for pattern in scope_patterns:
+        conn.execute(
+            "INSERT INTO task_scope (task_id, pattern, source) "
+            "VALUES (?, ?, 'operator_declared')",
+            (task_id, pattern),
+        )
+    for path in creates_paths:
+        conn.execute(
+            "INSERT INTO task_scope (task_id, pattern, source) "
+            "VALUES (?, ?, 'creates')",
+            (task_id, path),
+        )
+    if unbounded:
+        # Pattern is a sentinel — the scope guard short-circuits when any row
+        # for the task has source='unbounded' (emits no patterns, silent pass).
+        conn.execute(
+            "INSERT INTO task_scope (task_id, pattern, source) "
+            "VALUES (?, '**', 'unbounded')",
+            (task_id,),
+        )
+    else:
+        # Auto-extract paths from summary/description/criteria/specs. Mirrors
+        # the migration-73 backfill so fresh tasks land with task_scope rows
+        # equivalent to the legacy scope-path fallback.
+        explicit_patterns = set(scope_patterns) | set(creates_paths)
+        text_blocks = [summary or "", description or ""]
+        for c in criteria:
+            text_blocks.append(c or "")
+        for tc in typed_criteria:
+            text_blocks.append(tc.get("text") or "")
+            text_blocks.append(tc.get("spec") or "")
+        seen_auto: set = set()
+        requires_unit_tests = any(
+            _UNIT_TEST_REQUIREMENT_RE.search(block or "")
+            for block in text_blocks
+        )
+        for text in text_blocks:
+            for p in _auto_scope_candidates(
+                text,
+                repo_root=repo_root,
+                task_type=task_type,
+                requires_unit_tests=requires_unit_tests,
+            ):
+                resolved = _resolve_auto_derived_scope_pattern(repo_root, p)
+                is_explicit_github_path = p.startswith(".github/") and p != ".github/"
+                if (
+                    not is_explicit_github_path
+                    and is_prose_identifier_path(p, repo_root)
+                ):
+                    continue
+                if resolved in _git_helpers.SCOPE_DERIVE_BOOKKEEPING_DENYLIST:
+                    continue
+                if not _git_helpers.is_trackable_scope_pattern(repo_root, resolved):
+                    continue
+                if resolved in explicit_patterns or resolved in seen_auto:
+                    continue
+                seen_auto.add(resolved)
+                conn.execute(
+                    "INSERT INTO task_scope (task_id, pattern, source) "
+                    "VALUES (?, ?, 'auto_derived')",
+                    (task_id, resolved),
+                )
+
+    return InsertTaskResult(task_id, criteria_ids, typed_inserted)
+
+
 def main(argv: list[str]) -> int:
     db_path = argv[0]
     config_path = argv[1]
@@ -1082,162 +1259,38 @@ def main(argv: list[str]) -> int:
             print(dumps(result))
             return 1
 
-    # Compute expires_at
-    expires_at_expr = None
-    if expires_in_days is not None:
-        expires_at_expr = f"+{expires_in_days} days"
-
     # Insert task + criteria in one transaction
     conn = get_connection(db_path)
     try:
-        if fixes_task_id is not None:
-            row = conn.execute(
-                "SELECT 1 FROM tasks WHERE id = ?", (fixes_task_id,)
-            ).fetchone()
-            if row is None:
-                print(
-                    f"Error: --fixes-task-id {fixes_task_id} does not reference an existing task",
-                    file=sys.stderr,
-                )
-                return 2
-
-        if expires_at_expr:
-            conn.execute(
-                "INSERT INTO tasks (summary, description, status, priority, domain, "
-                "task_type, assignee, complexity, workflow, fixes_task_id, "
-                "expires_at, not_before, created_at, updated_at) "
-                "VALUES (?, ?, 'To Do', ?, ?, ?, ?, ?, ?, ?, datetime('now', ?), "
-                "?, datetime('now'), datetime('now'))",
-                (summary, description, priority, domain, task_type, assignee,
-                 complexity, workflow, fixes_task_id, expires_at_expr, not_before),
-            )
-        else:
-            conn.execute(
-                "INSERT INTO tasks (summary, description, status, priority, domain, "
-                "task_type, assignee, complexity, workflow, fixes_task_id, "
-                "not_before, created_at, updated_at) "
-                "VALUES (?, ?, 'To Do', ?, ?, ?, ?, ?, ?, ?, ?, datetime('now'), datetime('now'))",
-                (summary, description, priority, domain, task_type, assignee,
-                 complexity, workflow, fixes_task_id, not_before),
-            )
-
-        task_id = conn.execute("SELECT last_insert_rowid()").fetchone()[0]
-
-        criteria_ids = []
-        for criterion in criteria:
-            conn.execute(
-                "INSERT INTO acceptance_criteria (task_id, criterion, source) "
-                "VALUES (?, ?, 'original')",
-                (task_id, criterion),
-            )
-            cid = conn.execute("SELECT last_insert_rowid()").fetchone()[0]
-            criteria_ids.append(cid)
-
-        typed_inserted = []
-        for tc in typed_criteria:
-            conn.execute(
-                "INSERT INTO acceptance_criteria "
-                "(task_id, criterion, source, criterion_type, verification_spec) "
-                "VALUES (?, ?, 'original', ?, ?)",
-                (task_id, tc["text"], tc.get("type", "manual"), tc.get("spec")),
-            )
-            cid = conn.execute("SELECT last_insert_rowid()").fetchone()[0]
-            criteria_ids.append(cid)
-            typed_inserted.append((cid, tc.get("type", "manual"), tc.get("spec")))
-
-        for pattern in scope_patterns:
-            conn.execute(
-                "INSERT INTO task_scope (task_id, pattern, source) "
-                "VALUES (?, ?, 'operator_declared')",
-                (task_id, pattern),
-            )
-        for path in creates_paths:
-            conn.execute(
-                "INSERT INTO task_scope (task_id, pattern, source) "
-                "VALUES (?, ?, 'creates')",
-                (task_id, path),
-            )
-        if unbounded:
-            # Pattern is a sentinel — the scope guard short-circuits when any
-            # row for the task has source='unbounded' (emits no patterns,
-            # silent pass).
-            conn.execute(
-                "INSERT INTO task_scope (task_id, pattern, source) "
-                "VALUES (?, '**', 'unbounded')",
-                (task_id,),
-            )
-        else:
-            # Auto-extract paths from summary/description/criteria/specs.
-            # Mirrors the migration-73 backfill (which used
-            # task_referenced_paths) so new tasks land with the same
-            # task_scope shape that the scope-paths fallback would have
-            # inferred from a legacy task. Explicit --scope and --creates
-            # rows already inserted above win — auto_derived is only added
-            # for paths the operator didn't already declare.
-            explicit_patterns = set(scope_patterns) | set(creates_paths)
-            text_blocks = [summary or "", description or ""]
-            for c in criteria:
-                text_blocks.append(c or "")
-            for tc in typed_criteria:
-                text_blocks.append(tc.get("text") or "")
-                text_blocks.append(tc.get("spec") or "")
-            seen_auto: set = set()
-            requires_unit_tests = any(
-                _UNIT_TEST_REQUIREMENT_RE.search(block or "")
-                for block in text_blocks
-            )
-            for text in text_blocks:
-                for p in _auto_scope_candidates(
-                    text,
-                    repo_root=repo_root,
-                    task_type=task_type,
-                    requires_unit_tests=requires_unit_tests,
-                ):
-                    resolved = _resolve_auto_derived_scope_pattern(repo_root, p)
-                    # ``.github/`` is a real, ubiquitous repo directory, so any
-                    # path under it is a genuine reference — never a prose
-                    # identifier. The earlier carve-out only matched the
-                    # trailing-slash *directory* form (``.github/workflows/``)
-                    # and so dropped concrete *file* mentions like
-                    # ``.github/workflows/web-ci.yml`` whenever that file did
-                    # not yet exist on disk, because is_prose_identifier_path
-                    # classifies any non-existent dot-first-segment path as
-                    # prose (issue #1084 — co-discovered genuine regression
-                    # from the TASK-549 prose filter).
-                    is_explicit_github_path = p.startswith(".github/") and p != ".github/"
-                    if (
-                        not is_explicit_github_path
-                        and is_prose_identifier_path(p, repo_root)
-                    ):
-                        continue
-                    # Universal bookkeeping files (VERSION, CHANGELOG.md) that a
-                    # description merely *discusses* must not become auto_derived
-                    # scope rows — same defect #1104 fixed for the convergence
-                    # hint, here at the scope-derive consumer (issue #1105). An
-                    # explicit --scope/--creates VERSION already landed above and
-                    # is preserved via the explicit_patterns short-circuit below.
-                    if resolved in _git_helpers.SCOPE_DERIVE_BOOKKEEPING_DENYLIST:
-                        continue
-                    # Drop description/issue-body paths that name no tracked file
-                    # and live under no existing tracked tree (e.g. consumer-repo
-                    # paths quoted in a GitHub issue body). Applies the same
-                    # tracked-path validation the worktree cone derivation uses
-                    # (issue #1044) so the scope table and the cone no longer
-                    # diverge into phantom auto_derived rows (issue #1116).
-                    if not _git_helpers.is_trackable_scope_pattern(
-                        repo_root, resolved
-                    ):
-                        continue
-                    if resolved in explicit_patterns or resolved in seen_auto:
-                        continue
-                    seen_auto.add(resolved)
-                    conn.execute(
-                        "INSERT INTO task_scope (task_id, pattern, source) "
-                        "VALUES (?, ?, 'auto_derived')",
-                        (task_id, resolved),
-                    )
+        inserted = insert_task_record(
+            conn,
+            summary=summary,
+            description=description,
+            priority=priority,
+            domain=domain,
+            task_type=task_type,
+            assignee=assignee,
+            complexity=complexity,
+            workflow=workflow,
+            criteria=criteria,
+            typed_criteria=typed_criteria,
+            repo_root=repo_root,
+            expires_in_days=expires_in_days,
+            not_before=not_before,
+            fixes_task_id=fixes_task_id,
+            scope_patterns=scope_patterns,
+            creates_paths=creates_paths,
+            unbounded=unbounded,
+        )
+        task_id = inserted.task_id
+        criteria_ids = inserted.criteria_ids
+        typed_inserted = inserted.typed_inserted
 
         conn.commit()
+    except ValueError as e:
+        conn.rollback()
+        print(f"Error: {e}", file=sys.stderr)
+        return 2
     except sqlite3.Error as e:
         conn.rollback()
         print(f"Database error: {e}", file=sys.stderr)

--- a/tests/unit/test_task_import.py
+++ b/tests/unit/test_task_import.py
@@ -266,3 +266,202 @@ def test_import_accepts_json_from_stdin_and_writes_rows(tmp_path, monkeypatch):
         "SELECT relationship_type FROM task_dependencies WHERE task_id = 2 AND depends_on_id = 1"
     ).fetchone()[0] == "blocks"
     conn.close()
+
+
+def test_import_materializes_task_insert_metadata_criteria_and_scope(tmp_path):
+    db_path = _make_db(tmp_path)
+    config_path = _write_config(tmp_path / "config.json")
+    conn = sqlite3.connect(db_path)
+    conn.execute(
+        "INSERT INTO tasks (summary, description, status) VALUES (?, ?, 'Done')",
+        ("Original bug", "Already fixed"),
+    )
+    conn.commit()
+    conn.close()
+    plan = tmp_path / "tasks.json"
+    plan.write_text(
+        json.dumps({
+            "tasks": [
+                {
+                    "key": "full",
+                    "summary": "Imported full metadata task",
+                    "description": "Update bin/tusk-task-import.py",
+                    "priority": "high",
+                    "domain": "cli",
+                    "task_type": "bug",
+                    "assignee": "codex",
+                    "complexity": "L",
+                    "workflow": "planning",
+                    "expires_in": 3,
+                    "not_before": "2026-08-01T12:00:00Z",
+                    "fixes_task_id": 1,
+                    "scope": ["bin/tusk-task-import.py"],
+                    "creates": ["bin/import-generated.py"],
+                    "unbounded": True,
+                    "criteria": [
+                        "Manual criterion",
+                        {
+                            "text": "Run import unit test",
+                            "type": "test",
+                            "spec": "python3 -m pytest tests/unit/test_task_import.py -q",
+                        },
+                    ],
+                }
+            ]
+        }),
+        encoding="utf-8",
+    )
+
+    code, payload, _err = _run_import(db_path, config_path, ["--file", str(plan)])
+
+    assert code == 0
+    assert payload["created"]["0"]["key"] == "full"
+    assert payload["created"]["0"]["task_id"] == 2
+    assert payload["created"]["0"]["criteria_ids"] == [1, 2]
+    conn = sqlite3.connect(db_path)
+    row = conn.execute(
+        """
+        SELECT summary, priority, domain, task_type, assignee, complexity,
+               workflow, expires_at, not_before, fixes_task_id
+        FROM tasks WHERE id = 2
+        """
+    ).fetchone()
+    assert row[:7] == (
+        "Imported full metadata task",
+        "High",
+        "cli",
+        "bug",
+        "codex",
+        "L",
+        "planning",
+    )
+    assert row[7] is not None
+    assert row[8] == "2026-08-01 12:00:00"
+    assert row[9] == 1
+    criteria = conn.execute(
+        """
+        SELECT criterion, criterion_type, verification_spec
+        FROM acceptance_criteria
+        WHERE task_id = 2
+        ORDER BY id
+        """
+    ).fetchall()
+    assert criteria == [
+        ("Manual criterion", "manual", None),
+        (
+            "Run import unit test",
+            "test",
+            "python3 -m pytest tests/unit/test_task_import.py -q",
+        ),
+    ]
+    scope_rows = conn.execute(
+        "SELECT pattern, source FROM task_scope WHERE task_id = 2 ORDER BY id"
+    ).fetchall()
+    assert scope_rows == [
+        ("bin/tusk-task-import.py", "operator_declared"),
+        ("bin/import-generated.py", "creates"),
+        ("**", "unbounded"),
+    ]
+    conn.close()
+
+
+def test_best_effort_records_created_skipped_and_failed_outcomes(tmp_path):
+    db_path = _make_db(tmp_path)
+    config_path = _write_config(tmp_path / "config.json")
+    plan = tmp_path / "tasks.json"
+    plan.write_text(
+        json.dumps({
+            "tasks": [
+                {
+                    "key": "created",
+                    "summary": "Created import task",
+                    "description": "Description",
+                    "criteria": ["Manual criterion"],
+                },
+                {
+                    "key": "failed",
+                    "summary": "Duplicate failure import task",
+                    "description": "Description",
+                    "criteria": ["Manual criterion"],
+                },
+                {
+                    "key": "skipped",
+                    "summary": "Duplicate skip import task",
+                    "description": "Description",
+                    "criteria": ["Manual criterion"],
+                    "duplicate_policy": "skip",
+                },
+            ]
+        }),
+        encoding="utf-8",
+    )
+
+    def dupes(summary, domain):
+        if summary == "Duplicate failure import task":
+            return {"id": 41, "summary": "Existing fail", "similarity": 0.9}
+        if summary == "Duplicate skip import task":
+            return {"id": 42, "summary": "Existing skip", "similarity": 0.91}
+        return None
+
+    code, payload, _err = _run_import(
+        db_path,
+        config_path,
+        ["--file", str(plan), "--best-effort"],
+        dupes=dupes,
+    )
+
+    assert code == 2
+    assert payload["created"]["0"]["key"] == "created"
+    assert payload["created"]["0"]["task_id"] == 1
+    assert payload["failed"]["1"]["key"] == "failed"
+    assert payload["failed"]["1"]["errors"] == [
+        {"field": "duplicate_policy", "message": "duplicate of TASK-41"}
+    ]
+    assert payload["skipped"]["2"]["key"] == "skipped"
+    assert payload["skipped"]["2"]["reason"] == "duplicate"
+    conn = sqlite3.connect(db_path)
+    assert conn.execute("SELECT summary FROM tasks").fetchall() == [("Created import task",)]
+    assert conn.execute("SELECT COUNT(*) FROM acceptance_criteria").fetchone()[0] == 1
+    conn.close()
+
+
+def test_atomic_mode_rolls_back_full_batch_when_later_task_fails(tmp_path):
+    db_path = _make_db(tmp_path)
+    config_path = _write_config(tmp_path / "config.json")
+    plan = tmp_path / "tasks.json"
+    plan.write_text(
+        json.dumps({
+            "tasks": [
+                {
+                    "key": "first",
+                    "summary": "First atomic import task",
+                    "description": "Description",
+                    "criteria": ["Manual criterion"],
+                },
+                {
+                    "key": "bad",
+                    "summary": "Bad atomic import task",
+                    "description": "Description",
+                    "fixes_task_id": 999,
+                    "criteria": ["Manual criterion"],
+                },
+            ]
+        }),
+        encoding="utf-8",
+    )
+
+    code, payload, _err = _run_import(db_path, config_path, ["--file", str(plan)])
+
+    assert code == 2
+    assert payload["created"] == {}
+    assert payload["failed"]["1"]["key"] == "bad"
+    assert payload["failed"]["1"]["errors"] == [
+        {
+            "field": "$",
+            "message": "--fixes-task-id 999 does not reference an existing task",
+        }
+    ]
+    conn = sqlite3.connect(db_path)
+    assert conn.execute("SELECT COUNT(*) FROM tasks").fetchone()[0] == 0
+    assert conn.execute("SELECT COUNT(*) FROM acceptance_criteria").fetchone()[0] == 0
+    conn.close()


### PR DESCRIPTION
## Summary
- extract shared task-insert materialization into insert_task_record
- route task-import creation through that helper without shelling out per task
- add --best-effort outcomes plus full metadata/scope import support

## Verification
- python3 -m pytest tests/unit/test_task_import.py tests/unit/test_workflow.py tests/unit/test_task_insert_scope_resolution.py -q
- python3 -m pytest tests/unit/ -q
- ./bin/tusk lint (passes; VERSION advisory expected for chain task)